### PR TITLE
Add fallback to Alfresco CacheStatistics when proper details are not available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.orderofthebee.support-tools</groupId>
     <artifactId>support-tools-parent</artifactId>
-    <version>0.0.1.0</version>
+    <version>1.0.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>OOTBee Support Tools - Parent</name>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.orderofthebee.support-tools</groupId>
         <artifactId>support-tools-parent</artifactId>
-        <version>0.0.1.0</version>
+        <version>1.0.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>support-tools-repo</artifactId>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js
@@ -61,7 +61,7 @@ function buildCacheInfo(cacheBeanName, cache, globalProperties)
     {
         if (cacheInfo.type === 'org.alfresco.repo.cache.DefaultSimpleCache')
         {
-            stats = Packages.org.orderofthebee.addons.support.tools.repo.caches.CacheReflectionUtils.getDefaultSimpleCacheStats(cache);
+            stats = Packages.org.orderofthebee.addons.support.tools.repo.caches.CacheLookupUtils.getDefaultSimpleCacheStats(cache);
 
             cacheInfo.cacheGets = stats.requestCount();
             cacheInfo.cacheHits = stats.hitCount();
@@ -73,7 +73,7 @@ function buildCacheInfo(cacheBeanName, cache, globalProperties)
         else if (cacheInfo.type === 'org.alfresco.enterprise.repo.cluster.cache.InvalidatingCache' && invHandler
                 && invHandler.backingObject !== undefined && invHandler.backingObject !== null)
         {
-            stats = Packages.org.orderofthebee.addons.support.tools.repo.caches.CacheReflectionUtils
+            stats = Packages.org.orderofthebee.addons.support.tools.repo.caches.CacheLookupUtils
                     .getHzInvalidatingCacheStats(invHandler.backingObject);
 
             cacheInfo.cacheGets = stats.requestCount();
@@ -86,7 +86,7 @@ function buildCacheInfo(cacheBeanName, cache, globalProperties)
         else if (cacheInfo.type === 'org.alfresco.enterprise.repo.cluster.cache.HazelcastSimpleCache' && invHandler
                 && invHandler.backingObject !== undefined && invHandler.backingObject !== null)
         {
-            stats = Packages.org.orderofthebee.addons.support.tools.repo.caches.CacheReflectionUtils
+            stats = Packages.org.orderofthebee.addons.support.tools.repo.caches.CacheLookupUtils
                     .getHzSimpleCacheStats(invHandler.backingObject);
 
             cacheInfo.cacheGets = stats.operationStats.numberOfGets;

--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/caches/CacheLookupUtils.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/caches/CacheLookupUtils.java
@@ -33,7 +33,7 @@ import com.google.common.cache.CacheStats;
 /**
  * @author Axel Faust, <a href="http://acosix.de">Acosix GmbH</a>
  */
-public class CacheReflectionUtils
+public class CacheLookupUtils
 {
 
     /**

--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/caches/CacheLookupUtils.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/caches/CacheLookupUtils.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2016 Axel Faust
- * Copyright (C) 2016 Order of the Bee
+ * Copyright (C) 2016, 2017 Axel Faust
+ * Copyright (C) 2016, 2017 Order of the Bee
  *
  * This file is part of Community Support Tools
  *
@@ -22,19 +22,43 @@ package org.orderofthebee.addons.support.tools.repo.caches;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Map;
 
+import org.alfresco.repo.cache.CacheStatistics;
 import org.alfresco.repo.cache.DefaultSimpleCache;
+import org.alfresco.repo.cache.NoStatsForCache;
+import org.alfresco.repo.cache.OperationStats;
 import org.alfresco.repo.cache.SimpleCache;
+import org.alfresco.repo.cache.TransactionStats.OpType;
+import org.alfresco.repo.cache.TransactionalCache;
+import org.alfresco.util.EqualsHelper;
 import org.alfresco.util.ParameterCheck;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.PropertyValue;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.config.TypedStringValue;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.context.ContextLoader;
+import org.springframework.web.context.WebApplicationContext;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheStats;
 
 /**
+ * This utility class abstracts common reverse or reflection-based lookup logic to access low-level cache implementations or statistics
+ * objects.
+ *
  * @author Axel Faust, <a href="http://acosix.de">Acosix GmbH</a>
  */
 public class CacheLookupUtils
 {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CacheLookupUtils.class);
 
     /**
      * Retrieves the statistics data from an Alfresco Enterprise Edition {@code InvalidatingCache}
@@ -105,5 +129,220 @@ public class CacheLookupUtils
 
         final CacheStats stats = ((Cache<?, ?>) googleCache).stats();
         return stats;
+    }
+
+    /**
+     * Resolves the {@link CacheStatistics cache statistics} of the {@link TransactionalCache transactional cache} instance that facades a
+     * specific {@link SimpleCache shared
+     * cache} and provides it in a more script-friendly representation.
+     *
+     * @param sharedCacheName
+     *            the name of the shared cache
+     * @return a facade to a snapshot of the cache statistics
+     */
+    public static AlfrescoCacheStatsFacade resolveStatisticsViaTransactional(final String sharedCacheName)
+    {
+        ParameterCheck.mandatoryString("sharedCacheName", sharedCacheName);
+
+        LOGGER.debug("Trying to resolve transactional cache for shared cache {}", sharedCacheName);
+
+        String txnCacheName = null;
+
+        final WebApplicationContext applicationContext = ContextLoader.getCurrentWebApplicationContext();
+
+        if (applicationContext instanceof ConfigurableApplicationContext)
+        {
+            final ConfigurableListableBeanFactory beanFactory = ((ConfigurableApplicationContext) applicationContext).getBeanFactory();
+            final String[] txnCacheBeanNames = applicationContext.getBeanNamesForType(TransactionalCache.class, false, false);
+
+            // this is a rather ugly reference lookup, but so far I see no other way
+            for (final String txnCacheBeanName : txnCacheBeanNames)
+            {
+                final BeanDefinition txnCacheDefinition = beanFactory.getBeanDefinition(txnCacheBeanName);
+
+                final PropertyValue sharedCacheValue = txnCacheDefinition.getPropertyValues().getPropertyValue("sharedCache");
+                final PropertyValue nameValue = txnCacheDefinition.getPropertyValues().getPropertyValue("name");
+                if (nameValue != null && sharedCacheValue != null)
+                {
+                    final Object sharedCacheRef = sharedCacheValue.getValue();
+                    if (sharedCacheRef instanceof RuntimeBeanReference)
+                    {
+                        final String sharedCacheBeanName = ((RuntimeBeanReference) sharedCacheRef).getBeanName();
+
+                        Object nameValueObj = nameValue.getValue();
+                        if (nameValueObj instanceof TypedStringValue)
+                        {
+                            nameValueObj = ((TypedStringValue) nameValueObj).getValue();
+                        }
+
+                        if (EqualsHelper.nullSafeEquals(sharedCacheBeanName, sharedCacheName))
+                        {
+                            if (txnCacheName != null)
+                            {
+                                LOGGER.info("Shared cache {} is referenced by multiple transactional caches", sharedCacheName);
+                                txnCacheName = null;
+                                break;
+                            }
+                            txnCacheName = String.valueOf(nameValueObj);
+                            LOGGER.debug("Resolved transactional cache {} for shared cache {}", txnCacheName, sharedCacheName);
+                        }
+                        else
+                        {
+                            try
+                            {
+                                final DefaultSimpleCache<?, ?> defaultSimpleCache = applicationContext.getBean(sharedCacheBeanName,
+                                        DefaultSimpleCache.class);
+                                if (EqualsHelper.nullSafeEquals(defaultSimpleCache.getCacheName(), sharedCacheName))
+                                {
+                                    if (txnCacheName != null)
+                                    {
+                                        LOGGER.info("Shared cache {} is referenced by multiple transactional caches", sharedCacheName);
+                                        txnCacheName = null;
+                                        break;
+                                    }
+                                    txnCacheName = String.valueOf(nameValueObj);
+                                    LOGGER.debug("Resolved transactional cache {} for shared cache {}", txnCacheName, sharedCacheName);
+                                }
+                                continue;
+                            }
+                            catch (final BeansException be)
+                            {
+                                // ignore - can be expected e.g. in EE or with alternative cache implementations
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (txnCacheName == null)
+            {
+                LOGGER.debug("Unable to resolve unique transactional cache for shared cache {}", sharedCacheName);
+            }
+        }
+        else
+        {
+            LOGGER.debug("Application context is not a configurable application context - unable to resolve transactional cache");
+        }
+
+        AlfrescoCacheStatsFacade facade = null;
+        if (txnCacheName != null)
+        {
+            final CacheStatistics cacheStatistics = applicationContext.getBean("cacheStatistics", CacheStatistics.class);
+            try
+            {
+                final Map<OpType, OperationStats> allStats = cacheStatistics.allStats(txnCacheName);
+                facade = new AlfrescoCacheStatsFacade(allStats);
+            }
+            catch (final NoStatsForCache e)
+            {
+                facade = new AlfrescoCacheStatsFacade(Collections.emptyMap());
+            }
+        }
+
+        return facade;
+    }
+
+    public static class AlfrescoCacheStatsFacade implements CacheMetrics
+    {
+
+        private final Map<OpType, OperationStats> stats;
+
+        public AlfrescoCacheStatsFacade(final Map<OpType, OperationStats> stats)
+        {
+            this.stats = stats;
+        }
+
+        /**
+         *
+         * {@inheritDoc}
+         */
+        @Override
+        public long getCacheGets()
+        {
+            return this.getCacheHits() + this.getCacheMisses();
+        }
+
+        /**
+         *
+         * {@inheritDoc}
+         */
+        @Override
+        public long getCacheHits()
+        {
+            final long cacheHits;
+
+            final OperationStats hitStats = this.stats.get(OpType.GET_HIT);
+            cacheHits = hitStats != null ? hitStats.getCount() : 0;
+
+            return cacheHits;
+        }
+
+        /**
+         *
+         * {@inheritDoc}
+         */
+        @Override
+        public long getCacheMisses()
+        {
+            final long cacheMisses;
+
+            final OperationStats missStats = this.stats.get(OpType.GET_MISS);
+            cacheMisses = missStats != null ? missStats.getCount() : 0;
+
+            return cacheMisses;
+        }
+
+        /**
+         *
+         * {@inheritDoc}
+         */
+        @Override
+        public double getCacheHitPercentage()
+        {
+            double cacheHitPercentage;
+
+            final long cacheGets = this.getCacheGets();
+            if (cacheGets == 0)
+            {
+                cacheHitPercentage = 100;
+            }
+            else
+            {
+                cacheHitPercentage = this.getCacheHits() / cacheGets * 100;
+            }
+            return cacheHitPercentage;
+        }
+
+        /**
+         *
+         * {@inheritDoc}
+         */
+        @Override
+        public double getCacheMissPercentage()
+        {
+            double cacheMissPercentage;
+
+            final long cacheGets = this.getCacheGets();
+            if (cacheGets == 0)
+            {
+                cacheMissPercentage = 0;
+            }
+            else
+            {
+                cacheMissPercentage = this.getCacheMisses() / cacheGets * 100;
+            }
+            return cacheMissPercentage;
+        }
+
+        /**
+         *
+         * {@inheritDoc}
+         */
+        @Override
+        public long getCacheEvictions()
+        {
+            // no way to know due to lack of details
+            return -1;
+        }
     }
 }

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.orderofthebee.support-tools</groupId>
         <artifactId>support-tools-parent</artifactId>
-        <version>0.0.1.0</version>
+        <version>1.0.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>support-tools-share</artifactId>


### PR DESCRIPTION
This PR adds a fallback to the Alfresco CacheStatistics utility (actively maintained by TransactionalCache instances that act as a facade to the actual cache) when proper cache metrics are not available. This helps to provide improved statistics e.g. for Hazelcast caches in Enterprise Edition or alternative cache implementations that do not expose metrics on their own using the CacheWithMetrics interface or an identical API.

I have tested this on Alfresco Community 5.2 (201701 GA) and Alfresco Enterprise 5.1