### PR TITLE
Fix potential cause of syntax error in Active Sessions tool regarding user list

### DIFF
--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions-update-users.lib.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions-update-users.lib.ftl
@@ -26,14 +26,16 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
 <#escape x as jsonUtils.encodeJSONString(x)>
 {
     "users": [
+    <#assign first = true />
     <#list userSessionData.unexpiredUsers as user>
-        <#if user??> 
+        <#if user??><#if !first>,</#if>
+            <#assign first = false />
             {
                 "username" : "${user.properties.userName!''}",
                 "firstName" : "${user.properties.firstName!''}",
                 "lastName" : "${user.properties.lastName!''}",
                 "email" : "${user.properties.email!''}"
-            }<#if user_has_next>,</#if>
+            }
         </#if> 
     </#list>
     ]


### PR DESCRIPTION
This PR addresses a potential cause for the issue #62.
Since a userName may resolve to a ```null``` cm:person node we need to make sure to only render a comma when any previous user data entry has been rendered.