### PR TITLE
Fix scaling for threads graph in Performance tool

### DIFF
--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions-update-users.lib.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions-update-users.lib.ftl
@@ -26,14 +26,16 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
 <#escape x as jsonUtils.encodeJSONString(x)>
 {
     "users": [
+    <#assign first = true />
     <#list userSessionData.unexpiredUsers as user>
-        <#if user??> 
+        <#if user??><#if !first>,</#if>
+            <#assign first = false />
             {
                 "username" : "${user.properties.userName!''}",
                 "firstName" : "${user.properties.firstName!''}",
                 "lastName" : "${user.properties.lastName!''}",
                 "email" : "${user.properties.email!''}"
-            }<#if user_has_next>,</#if>
+            }
         </#if> 
     </#list>
     ]

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get.html.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get.html.ftl
@@ -47,6 +47,16 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
     </div>
     <div class="column-left">
         <canvas id="database" width="350" height="150"></canvas>
+
+        <@options id="dbTimescale" name="dbTimescale" label=msg("activesessions.chart-timescale") value="10">
+            <@option label=msg("activesessions.chart-timescale.1min") value="1" />
+            <@option label=msg("activesessions.chart-timescale.10mins") value="10" />
+            <@option label=msg("activesessions.chart-timescale.60mins") value="60" />
+            <@option label=msg("activesessions.chart-timescale.12hrs") value="720" />
+            <@option label=msg("activesessions.chart-timescale.24hrs") value="1440" />
+            <@option label=msg("activesessions.chart-timescale.48hrs") value="2880" />
+            <@option label=msg("activesessions.chart-timescale.7days") value="10080" />
+        </@options>
     </div>
     <div class="column-right">
         <@field value=connectionPoolData.driverClassName label=msg("activesessions.database.driver")?html />
@@ -73,6 +83,16 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
     </div>
     <div class="column-left">
         <canvas id="users" width="350" height="150"></canvas>
+
+        <@options id="userTimescale" name="userTimescale" label=msg("activesessions.chart-timescale") value="10">
+            <@option label=msg("activesessions.chart-timescale.1min") value="1" />
+            <@option label=msg("activesessions.chart-timescale.10mins") value="10" />
+            <@option label=msg("activesessions.chart-timescale.60mins") value="60" />
+            <@option label=msg("activesessions.chart-timescale.12hrs") value="720" />
+            <@option label=msg("activesessions.chart-timescale.24hrs") value="1440" />
+            <@option label=msg("activesessions.chart-timescale.48hrs") value="2880" />
+            <@option label=msg("activesessions.chart-timescale.7days") value="10080" />
+        </@options>
     </div>
     <div class="column-right">
         <div class="control field">

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get.properties
@@ -21,3 +21,12 @@ activesessions.users.first-name=First Name
 activesessions.users.last-name=Last Name
 activesessions.users.email=Email
 activesessions.users.logoff=Logoff User
+
+activesessions.chart-timescale=Chart Timescale
+activesessions.chart-timescale.1min=1 Min
+activesessions.chart-timescale.10mins=10 Mins
+activesessions.chart-timescale.60mins=60 Mins
+activesessions.chart-timescale.12hrs=12 Hrs
+activesessions.chart-timescale.24hrs=24 Hrs
+activesessions.chart-timescale.48hrs=48 Hrs
+activesessions.chart-timescale.7days=7 Days

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get_de.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get_de.properties
@@ -21,3 +21,12 @@ activesessions.users.first-name=Vorname
 activesessions.users.last-name=Nachname
 activesessions.users.email=Email
 activesessions.users.logoff=Abmelden
+
+activesessions.chart-timescale=Skala der Zeitleiste
+activesessions.chart-timescale.1min=1 Minute
+activesessions.chart-timescale.10mins=10 Minuten
+activesessions.chart-timescale.60mins=1 Stunde
+activesessions.chart-timescale.12hrs=12 Stunden
+activesessions.chart-timescale.24hrs=1 Tag
+activesessions.chart-timescale.48hrs=2 Tage
+activesessions.chart-timescale.7days=7 Tage

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get_en.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get_en.properties
@@ -21,3 +21,12 @@ activesessions.users.first-name=First Name
 activesessions.users.last-name=Last Name
 activesessions.users.email=Email
 activesessions.users.logoff=Logoff User
+
+activesessions.chart-timescale=Chart Timescale
+activesessions.chart-timescale.1min=1 Min
+activesessions.chart-timescale.10mins=10 Mins
+activesessions.chart-timescale.60mins=60 Mins
+activesessions.chart-timescale.12hrs=12 Hrs
+activesessions.chart-timescale.24hrs=24 Hrs
+activesessions.chart-timescale.48hrs=48 Hrs
+activesessions.chart-timescale.7days=7 Days

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get_es.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get_es.properties
@@ -21,3 +21,12 @@ activesessions.users.first-name=Nombre
 activesessions.users.last-name=Apellidos
 activesessions.users.email=Correo
 activesessions.users.logoff=Desconectar Usuario
+
+activesessions.chart-timescale=Escala de Tiempo
+activesessions.chart-timescale.1min=1 Min
+activesessions.chart-timescale.10mins=10 Mins
+activesessions.chart-timescale.60mins=60 Mins
+activesessions.chart-timescale.12hrs=12 Hrs
+activesessions.chart-timescale.24hrs=24 Hrs
+activesessions.chart-timescale.48hrs=48 Hrs
+activesessions.chart-timescale.7days=7 D\u00edas

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get_fr.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get_fr.properties
@@ -21,3 +21,12 @@ activesessions.users.first-name=Pr\u00e9nom
 activesessions.users.last-name=Nom
 activesessions.users.email=Email
 activesessions.users.logoff=D\u00e9connecter utilisateur
+
+activesessions.chart-timescale=\u00c9chelle de temps
+activesessions.chart-timescale.1min=1 minute
+activesessions.chart-timescale.10mins=10 minutes
+activesessions.chart-timescale.60mins=60 minutes
+activesessions.chart-timescale.12hrs=12 heures
+activesessions.chart-timescale.24hrs=24 heures
+activesessions.chart-timescale.48hrs=48 heures
+activesessions.chart-timescale.7days=7 jours

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get_pt.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.get_pt.properties
@@ -21,3 +21,12 @@ activesessions.users.first-name=Primeiro Nome
 activesessions.users.last-name=\u00daltimo Nome
 activesessions.users.email=Email
 activesessions.users.logoff=Desconectar Us\u00e1rio
+
+activesessions.chart-timescale=Gr\u00e1fico de Escala de Tempo
+activesessions.chart-timescale.1min=1 Min
+activesessions.chart-timescale.10mins=10 Mins
+activesessions.chart-timescale.60mins=60 Mins
+activesessions.chart-timescale.12hrs=12 Hrs
+activesessions.chart-timescale.24hrs=24 Hrs
+activesessions.chart-timescale.48hrs=48 Hrs
+activesessions.chart-timescale.7days=7 Dias

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/performance.get.html.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/performance.get.html.ftl
@@ -50,14 +50,14 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
     </div>
 
     <div class="column-left">
-        <@options id="memTimescale" name="memTimescale" label=msg("performance.chart-timescale") value="11">
+        <@options id="memTimescale" name="memTimescale" label=msg("performance.chart-timescale") value="10">
             <@option label=msg("performance.chart-timescale.1min") value="1" />
-            <@option label=msg("performance.chart-timescale.10mins") value="11" />
-            <@option label=msg("performance.chart-timescale.60mins") value="61" />
-            <@option label=msg("performance.chart-timescale.12hrs") value="721" />
-            <@option label=msg("performance.chart-timescale.24hrs") value="1441" />
-            <@option label=msg("performance.chart-timescale.48hrs") value="2881" />
-            <@option label=msg("performance.chart-timescale.7days") value="10081" />
+            <@option label=msg("performance.chart-timescale.10mins") value="10" />
+            <@option label=msg("performance.chart-timescale.60mins") value="60" />
+            <@option label=msg("performance.chart-timescale.12hrs") value="720" />
+            <@option label=msg("performance.chart-timescale.24hrs") value="1440" />
+            <@option label=msg("performance.chart-timescale.48hrs") value="2880" />
+            <@option label=msg("performance.chart-timescale.7days") value="10080" />
         </@options>
     </div>
     <div class="column-right">
@@ -88,14 +88,14 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
     </div>
 
     <div class="column-left">
-        <@options id="cpuTimescale" name="cpuTimescale" label=msg("performance.chart-timescale") value="11">
+        <@options id="cpuTimescale" name="cpuTimescale" label=msg("performance.chart-timescale") value="10">
             <@option label=msg("performance.chart-timescale.1min") value="1" />
-            <@option label=msg("performance.chart-timescale.10mins") value="11" />
-            <@option label=msg("performance.chart-timescale.60mins") value="61" />
-            <@option label=msg("performance.chart-timescale.12hrs") value="721" />
-            <@option label=msg("performance.chart-timescale.24hrs") value="1441" />
-            <@option label=msg("performance.chart-timescale.48hrs") value="2881" />
-            <@option label=msg("performance.chart-timescale.7days") value="10081" />
+            <@option label=msg("performance.chart-timescale.10mins") value="10" />
+            <@option label=msg("performance.chart-timescale.60mins") value="60" />
+            <@option label=msg("performance.chart-timescale.12hrs") value="720" />
+            <@option label=msg("performance.chart-timescale.24hrs") value="1440" />
+            <@option label=msg("performance.chart-timescale.48hrs") value="2880" />
+            <@option label=msg("performance.chart-timescale.7days") value="10080" />
         </@options>
     </div>
     <div class="column-right">
@@ -117,14 +117,14 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
     </div>
 
     <div class="column-left">
-        <@options id="threadsTimescale" name="threadsTimescale" label=msg("performance.chart-timescale") value="11">
+        <@options id="threadsTimescale" name="threadsTimescale" label=msg("performance.chart-timescale") value="10">
             <@option label=msg("performance.chart-timescale.1min") value="1" />
-            <@option label=msg("performance.chart-timescale.10mins") value="11" />
-            <@option label=msg("performance.chart-timescale.60mins") value="61" />
-            <@option label=msg("performance.chart-timescale.12hrs") value="721" />
-            <@option label=msg("performance.chart-timescale.24hrs") value="1441" />
-            <@option label=msg("performance.chart-timescale.48hrs") value="2881" />
-            <@option label=msg("performance.chart-timescale.7days") value="10081" />
+            <@option label=msg("performance.chart-timescale.10mins") value="10" />
+            <@option label=msg("performance.chart-timescale.60mins") value="60" />
+            <@option label=msg("performance.chart-timescale.12hrs") value="720" />
+            <@option label=msg("performance.chart-timescale.24hrs") value="1440" />
+            <@option label=msg("performance.chart-timescale.48hrs") value="2880" />
+            <@option label=msg("performance.chart-timescale.7days") value="10080" />
         </@options>
     </div>
     <div class="column-right">

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/performance.get.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/performance.get.properties
@@ -20,5 +20,5 @@ performance.chart-timescale.10mins=10 Mins
 performance.chart-timescale.60mins=60 Mins
 performance.chart-timescale.12hrs=12 Hrs
 performance.chart-timescale.24hrs=24 Hrs
-performance.chart-timescale.48hrs=48 Hrs  
+performance.chart-timescale.48hrs=48 Hrs
 performance.chart-timescale.7days=7 Days

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/performance.get_de.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/performance.get_de.properties
@@ -20,5 +20,5 @@ performance.chart-timescale.10mins=10 Minuten
 performance.chart-timescale.60mins=1 Stunde
 performance.chart-timescale.12hrs=12 Stunden
 performance.chart-timescale.24hrs=1 Tag
-performance.chart-timescale.48hrs=2 Tage  
+performance.chart-timescale.48hrs=2 Tage
 performance.chart-timescale.7days=7 Tage

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/performance.get_en.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/performance.get_en.properties
@@ -20,5 +20,5 @@ performance.chart-timescale.10mins=10 Mins
 performance.chart-timescale.60mins=60 Mins
 performance.chart-timescale.12hrs=12 Hrs
 performance.chart-timescale.24hrs=24 Hrs
-performance.chart-timescale.48hrs=48 Hrs  
+performance.chart-timescale.48hrs=48 Hrs
 performance.chart-timescale.7days=7 Days

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/performance.get_es.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/performance.get_es.properties
@@ -20,5 +20,5 @@ performance.chart-timescale.10mins=10 Mins
 performance.chart-timescale.60mins=60 Mins
 performance.chart-timescale.12hrs=12 Hrs
 performance.chart-timescale.24hrs=24 Hrs
-performance.chart-timescale.48hrs=48 Hrs  
+performance.chart-timescale.48hrs=48 Hrs
 performance.chart-timescale.7days=7 D\u00edas

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/performance.get_pt.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/performance.get_pt.properties
@@ -20,5 +20,5 @@ performance.chart-timescale.10mins=10 Mins
 performance.chart-timescale.60mins=60 Mins
 performance.chart-timescale.12hrs=12 Hrs
 performance.chart-timescale.24hrs=24 Hrs
-performance.chart-timescale.48hrs=48 Hrs  
+performance.chart-timescale.48hrs=48 Hrs
 performance.chart-timescale.7days=7 Dias

--- a/repository/src/main/amp/web/ootbee-support-tools/js/performance-monitor.js
+++ b/repository/src/main/amp/web/ootbee-support-tools/js/performance-monitor.js
@@ -40,17 +40,17 @@ var AdminSP = AdminSP || {};
     {
         AdminSP.createCharts();
 
-        Admin.addEventListener(el("memTimescale"), "change", function()
+        Admin.addEventListener(el('memTimescale'), 'change', function()
         {
-            AdminSP.changeChartTimescale(this, el("memory"), memGraph);
+            AdminSP.changeChartTimescale(this, el('memory'), memGraph);
         });
-        Admin.addEventListener(el("cpuTimescale"), "change", function()
+        Admin.addEventListener(el('cpuTimescale'), 'change', function()
         {
-            AdminSP.changeChartTimescale(this, el("CPU"), cpuGraph);
+            AdminSP.changeChartTimescale(this, el('CPU'), cpuGraph);
         });
-        Admin.addEventListener(el("threadsTimescale"), "change", function()
+        Admin.addEventListener(el('threadsTimescale'), 'change', function()
         {
-            AdminSP.changeChartTimescale(this, el("Threads"), threadGraph);
+            AdminSP.changeChartTimescale(this, el('Threads'), threadGraph);
         });
     });
 
@@ -84,9 +84,9 @@ var AdminSP = AdminSP || {};
         {
             var memoryCanvas, cpuCanvas, threadCanvas;
 
-            memoryCanvas = el("memory");
-            cpuCanvas = el("CPU");
-            threadCanvas = el("Threads");
+            memoryCanvas = el('memory');
+            cpuCanvas = el('CPU');
+            threadCanvas = el('Threads');
             memoryCanvas.width = memoryCanvas.parentNode.clientWidth;
             cpuCanvas.width = cpuCanvas.parentNode.clientWidth;
             threadCanvas.width = threadCanvas.parentNode.clientWidth;
@@ -97,7 +97,7 @@ var AdminSP = AdminSP || {};
         setInterval(function()
         {
             Admin.request({
-                url : serviceUrl + "?format=json",
+                url : serviceUrl + '?format=json',
                 fnSuccess : function(res)
                 {
                     var json, now;
@@ -107,15 +107,15 @@ var AdminSP = AdminSP || {};
                         json = res.responseJSON;
                         now = new Date().getTime();
 
-                        el("MaxMemory").innerHTML = json.MaxMemory;
-                        el("TotalMemory").innerHTML = json.TotalMemory;
-                        el("UsedMemory").innerHTML = json.UsedMemory;
-                        el("FreeMemory").innerHTML = json.FreeMemory;
+                        el('MaxMemory').innerHTML = json.MaxMemory;
+                        el('TotalMemory').innerHTML = json.TotalMemory;
+                        el('UsedMemory').innerHTML = json.UsedMemory;
+                        el('FreeMemory').innerHTML = json.FreeMemory;
 
-                        el("ProcessLoad").innerHTML = json.ProcessLoad;
-                        el("SystemLoad").innerHTML = json.SystemLoad;
-                        el("ThreadCount").innerHTML = json.ThreadCount;
-                        el("PeakThreadCount").innerHTML = json.PeakThreadCount;
+                        el('ProcessLoad').innerHTML = json.ProcessLoad;
+                        el('SystemLoad').innerHTML = json.SystemLoad;
+                        el('ThreadCount').innerHTML = json.ThreadCount;
+                        el('PeakThreadCount').innerHTML = json.PeakThreadCount;
 
                         memChartLineComtd.append(now, json.TotalMemory);
                         memChartLineUsed.append(now, json.UsedMemory);
@@ -155,7 +155,7 @@ var AdminSP = AdminSP || {};
             fillStyle : 'rgba(0, 0, 255, 0.3)',
             lineWidth : 2
         });
-        memGraph.streamTo(document.getElementById("memory"), 1000);
+        memGraph.streamTo(document.getElementById('memory'), 1000);
 
         cpuGraph = new SmoothieChart({
             labels : {
@@ -185,7 +185,7 @@ var AdminSP = AdminSP || {};
             fillStyle : 'rgba(255, 100, 100, 0.3)',
             lineWidth : 2
         });
-        cpuGraph.streamTo(document.getElementById("CPU"), 1000);
+        cpuGraph.streamTo(document.getElementById('CPU'), 1000);
 
         threadGraph = new SmoothieChart({
             labels : {
@@ -210,7 +210,7 @@ var AdminSP = AdminSP || {};
             fillStyle : 'rgba(56, 187, 56, 0.3)',
             lineWidth : 2
         });
-        threadGraph.streamTo(document.getElementById("Threads"), 1000);
+        threadGraph.streamTo(document.getElementById('Threads'), 1000);
     };
 
     AdminSP.changeChartTimescale = function changeChartTimescale(element, canvas, chart)

--- a/repository/src/main/amp/web/ootbee-support-tools/js/performance-monitor.js
+++ b/repository/src/main/amp/web/ootbee-support-tools/js/performance-monitor.js
@@ -195,7 +195,7 @@ var AdminSP = AdminSP || {};
             sieve : true,
             timestampFormatter : SmoothieChart.timeFormatter,
             millisPerPixel : 1000,
-            maxValue : initialThreadMetrics.PeakThreadCount,
+            maxValueScale : 1.25,
             minValue : 0,
             grid : {
                 strokeStyle : '#cccccc',


### PR DESCRIPTION
Resolves #60 

This PR changes the scaling of the threads graph in the Performance tool to always add keep ~25% space above the max value and not fix the scale to a particular value when the graph is initialised.

This PR already builds upon PR #67 to make it easier to simply merge by rebasing on top of master when #67 has been merged.