### PR TITLE
Add support for clearing caches (w/ restriction)

### DIFF
--- a/repository/src/main/amp/config/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
+++ b/repository/src/main/amp/config/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
@@ -1,10 +1,11 @@
 ootbee-support-tools.systeminformation.sensitiveKeys=api.key,password
 
-ootbee-support-tools.cache.disallowClear=false
-ootbee-support-tools.cache.default.disallowClear=false
-ootbee-support-tools.cache.invalidating.disallowClear=false
-ootbee-support-tools.cache.distributed.disallowClear=false
-ootbee-support-tools.cache.unknown.disallowClear=false
+ootbee-support-tools.cache.allowClear=true
+ootbee-support-tools.cache.memory.allowClear=true
+ootbee-support-tools.cache.default.allowClear=true
+ootbee-support-tools.cache.invalidating.allowClear=true
+ootbee-support-tools.cache.distributed.allowClear=true
+ootbee-support-tools.cache.unknown.allowClear=false
 
 # define all the caches that we consider clearable without breaking Alfresco
 cache.propertyValueCache.clearable=true

--- a/repository/src/main/amp/config/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
+++ b/repository/src/main/amp/config/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
@@ -1,1 +1,49 @@
-support-tools.systeminformation.sensitiveKeys=api.key,password
+ootbee-support-tools.systeminformation.sensitiveKeys=api.key,password
+
+ootbee-support-tools.cache.disallowClear=false
+ootbee-support-tools.cache.default.disallowClear=false
+ootbee-support-tools.cache.invalidating.disallowClear=false
+ootbee-support-tools.cache.distributed.disallowClear=false
+ootbee-support-tools.cache.unknown.disallowClear=false
+
+# define all the caches that we consider clearable without breaking Alfresco
+cache.propertyValueCache.clearable=true
+cache.propertyClassCache.clearable=true
+cache.contentDataSharedCache.clearable=true
+cache.contentUrlSharedCache.clearable=true
+cache.contentUrlMasterKeySharedCache.clearable=true
+cache.contentUrlEncryptingMasterKeySharedCache.clearable=true
+cache.immutableEntitySharedCache.clearable=true
+cache.node.rootNodesSharedCache.clearable=true
+cache.node.allRootNodesSharedCache.clearable=true
+cache.node.nodesSharedCache.clearable=true
+cache.node.aspectsSharedCache.clearable=true
+cache.node.propertiesSharedCache.clearable=true
+# this isn't really a real cache but still defined in caches.properties so we include it here as well
+cache.node.parentAssocsSharedCache.clearable=true
+cache.node.childByNameSharedCache.clearable=true
+cache.userToAuthoritySharedCache.clearable=true
+cache.authenticationSharedCache.clearable=true
+cache.authoritySharedCache.clearable=true
+cache.authorityToChildAuthoritySharedCache.clearable=true
+cache.zoneToAuthoritySharedCache.clearable=true
+cache.permissionsAccessSharedCache.clearable=true
+cache.readersSharedCache.clearable=true
+cache.readersDeniedSharedCache.clearable=true
+cache.nodeOwnerSharedCache.clearable=true
+cache.nodeRulesSharedCache.clearable=true
+cache.personSharedCache.clearable=true
+# clearing the tickets cache will effectively invalidate all active user sessions
+cache.ticketsCache.clearable=true
+cache.authorityEntitySharedCache.clearable=true
+cache.aclSharedCache.clearable=true
+cache.aclEntitySharedCache.clearable=true
+cache.tagscopeSummarySharedCache.clearable=true
+cache.imapMessageSharedCache.clearable=true
+cache.tenantEntitySharedCache.clearable=true
+cache.permissionEntitySharedCache.clearable=true
+cache.propertyUniqueContextSharedCache.clearable=true
+cache.siteNodeRefSharedCache.clearable=true
+cache.solrFacetNodeRefSharedCache.clearable=true
+
+# other caches we currently assume are not safe to be cleared at runtime

--- a/repository/src/main/amp/config/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
+++ b/repository/src/main/amp/config/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
@@ -1,11 +1,11 @@
 ootbee-support-tools.systeminformation.sensitiveKeys=api.key,password
 
-ootbee-support-tools.cache.allowClear=true
-ootbee-support-tools.cache.memory.allowClear=true
-ootbee-support-tools.cache.default.allowClear=true
-ootbee-support-tools.cache.invalidating.allowClear=true
-ootbee-support-tools.cache.distributed.allowClear=true
-ootbee-support-tools.cache.unknown.allowClear=false
+ootbee-support-tools.cache.clearable=true
+ootbee-support-tools.cache.memory.clearable=true
+ootbee-support-tools.cache.default.clearable=true
+ootbee-support-tools.cache.invalidating.clearable=true
+ootbee-support-tools.cache.distributed.clearable=true
+ootbee-support-tools.cache.unknown.clearable=false
 
 # define all the caches that we consider clearable without breaking Alfresco
 cache.propertyValueCache.clearable=true

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.desc.xml
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.desc.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<webscript>
+    <shortname>Clear Cache</shortname>
+    <description>Clear contents of a cache</description>
+    <url>/ootbee/admin/caches/{cache}/clear</url>
+    <family>OOTBee Support Tools</family>
+    <format default="json" />
+    <authentication>admin</authentication>
+    <lifecycle>internal</lifecycle>
+    <transaction>none</transaction>
+</webscript>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.js
@@ -1,0 +1,28 @@
+<import resource="classpath:alfresco/templates/webscripts/org/alfresco/repository/admin/admin-common.lib.js">
+<import resource="classpath:alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js">
+
+/**
+ * Copyright (C) 2017 Axel Faust
+ * Copyright (C) 2017 Order of the Bee
+ *
+ * This file is part of Community Support Tools
+ *
+ * Community Support Tools is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Community Support Tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Linked to Alfresco
+ * Copyright (C) 2005-2017 Alfresco Software Limited.
+ */
+
+resetCache(String(url.templateArgs.cache).replace(/%dot%/g, '.'));

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.json.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.json.ftl
@@ -1,0 +1,28 @@
+<#compress>
+<#-- 
+Copyright (C) 2016 Axel Faust / Markus Joos
+Copyright (C) 2016 Order of the Bee
+
+This file is part of Community Support Tools
+
+Community Support Tools is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Community Support Tools is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
+
+Linked to Alfresco
+Copyright (C) 2005-2016 Alfresco Software Limited.
+ 
+  -->
+  
+{
+}
+</#compress>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.json.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.json.ftl
@@ -1,7 +1,7 @@
 <#compress>
 <#-- 
-Copyright (C) 2016 Axel Faust / Markus Joos
-Copyright (C) 2016 Order of the Bee
+Copyright (C) 2017 Axel Faust / Markus Joos
+Copyright (C) 2017 Order of the Bee
 
 This file is part of Community Support Tools
 
@@ -19,7 +19,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
 
 Linked to Alfresco
-Copyright (C) 2005-2016 Alfresco Software Limited.
+Copyright (C) 2005-2017 Alfresco Software Limited.
  
   -->
   

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.html.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.html.ftl
@@ -1,6 +1,6 @@
 <#-- 
-Copyright (C) 2016 Axel Faust
-Copyright (C) 2016 Order of the Bee
+Copyright (C) 2016, 2017 Axel Faust
+Copyright (C) 2016, 2017 Order of the Bee
 
 This file is part of Community Support Tools
 
@@ -18,7 +18,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
 
 Linked to Alfresco
-Copyright (C) 2005-2016 Alfresco Software Limited.
+Copyright (C) 2005-2017 Alfresco Software Limited.
  
   -->
 

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.html.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.html.ftl
@@ -27,6 +27,10 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
 <@page title=msg("caches.title") readonly=true customCSSFiles=["ootbee-support-tools/css/jquery.dataTables.css"]
     customJSFiles=["ootbee-support-tools/js/jquery-2.2.3.js", "ootbee-support-tools/js/jquery.dataTables.js", "ootbee-support-tools/js/caches.js"]>
 
+<script type="text/javascript">//<![CDATA[
+    AdminCA.setServiceContext('${url.serviceContext}');
+//]]></script>
+
     <div class="column-full">
         <p class="intro">${msg("caches.intro")?html}</p>      
 
@@ -48,6 +52,7 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
                         <th>${msg("caches.attr.cacheMissPercentage")?html}</th>
 
                         <th>${msg("caches.attr.cacheEvictions")?html}</th>
+                        <th></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -67,6 +72,7 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
                             <td class="numericalCellValue"><#if cacheInfo.cacheMissRate &gt;= 0>${cacheInfo.cacheMissRate?string["0.0"]}</#if></td>
                             
                             <td class="numericalCellValue"><#if cacheInfo.cacheEvictions &gt;= 0>${cacheInfo.cacheEvictions?c}</#if></td>
+                            <td><#if cacheInfo.clearable><a href="#" onclick="AdminCA.clearCache('${cacheInfo.name}');" title="${msg("caches.clearCache.title")?html}">${msg("caches.clearCache.label")?html}</a></#if></td>
                         </tr>
                     </#list>
                 </tbody>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.js
@@ -2,8 +2,8 @@
 <import resource="classpath:alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js">
 
 /**
- * Copyright (C) 2016 Axel Faust
- * Copyright (C) 2016 Order of the Bee
+ * Copyright (C) 2016, 2017 Axel Faust
+ * Copyright (C) 2016, 2017 Order of the Bee
  *
  * This file is part of Community Support Tools
  *
@@ -22,7 +22,7 @@
  */
 /*
  * Linked to Alfresco
- * Copyright (C) 2005-2016 Alfresco Software Limited.
+ * Copyright (C) 2005-2017 Alfresco Software Limited.
  */
 
 buildCaches();

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.properties
@@ -17,3 +17,6 @@ caches.attr.cacheMissPercentage=Miss %
 caches.attr.cacheEvictions=# evictions
 
 caches.typeNotSet=
+
+caches.clearCache.label=Clear
+caches.clearCache.title=Clears the entire contents of this cache. This can have serious impact on performance and will propagate in a cluster.

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get_de.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get_de.properties
@@ -17,3 +17,6 @@ caches.attr.cacheMissPercentage=Fehler %
 caches.attr.cacheEvictions=# L\u00f6schungen
 
 caches.typeNotSet=
+
+caches.clearCache.label=Leeren
+caches.clearCache.title=Entfernt die Inhalte dieses Caches. Diese Aktion kann signifikante Auswirkungen auf die Leistung des Systems haben.

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get_en.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get_en.properties
@@ -17,3 +17,6 @@ caches.attr.cacheMissPercentage=Miss %
 caches.attr.cacheEvictions=# evictions
 
 caches.typeNotSet=
+
+caches.clearCache.label=Clear
+caches.clearCache.title=Clears the entire contents of this cache. This can have serious impact on performance and will propagate in a cluster.

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get_es.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get_es.properties
@@ -18,3 +18,6 @@ caches.attr.cacheMissPercentage=Miss %
 caches.attr.cacheEvictions=# evictions
 
 caches.typeNotSet=
+
+caches.clearCache.label=Borrar
+caches.clearCache.title=Borra completamente el contenido de la Cache. Esto puede tener un impacto alto en el rendimiento y propagado por el cluster.

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get_pt.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get_pt.properties
@@ -17,3 +17,7 @@ caches.attr.cacheMissPercentage=Perdas %
 caches.attr.cacheEvictions=# despejos
 
 caches.typeNotSet=
+
+caches.clearCache.label=Limpar
+caches.clearCache.title=Limpar os conte\u00fados da cache. Pode ter um s\u00e9rio impacto na performance e ir\u00e1 ser propagado pelo cluster.
+Clears the entire contents of this cache. This can have serious impact on performance and will propagate in a cluster.

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js
@@ -112,7 +112,7 @@ function buildCacheInfo(cacheName, cache, allowClearGlobal, propertyGetter)
                 }
 
                 cacheInfo.clearable = cacheInfo.clearable
-                        && propertyGetter('ootbee-support-tools.cache.memory.allowClear', '').toLowerCase() === 'true';
+                        && propertyGetter('ootbee-support-tools.cache.memory.clearable', '').toLowerCase() === 'true';
                 break;
             case 'org.alfresco.repo.cache.DefaultSimpleCache':
                 stats = Packages.org.orderofthebee.addons.support.tools.repo.caches.CacheLookupUtils.getDefaultSimpleCacheStats(cache);
@@ -125,7 +125,7 @@ function buildCacheInfo(cacheName, cache, allowClearGlobal, propertyGetter)
                 cacheInfo.cacheMissRate = stats.missRate() * 100;
 
                 cacheInfo.clearable = cacheInfo.clearable
-                        && propertyGetter('ootbee-support-tools.cache.default.allowClear', '').toLowerCase() === 'true';
+                        && propertyGetter('ootbee-support-tools.cache.default.clearable', '').toLowerCase() === 'true';
                 break;
             case 'org.alfresco.enterprise.repo.cluster.cache.InvalidatingCache':
                 stats = Packages.org.orderofthebee.addons.support.tools.repo.caches.CacheLookupUtils.getHzInvalidatingCacheStats(cache);
@@ -138,7 +138,7 @@ function buildCacheInfo(cacheName, cache, allowClearGlobal, propertyGetter)
                 cacheInfo.cacheMissRate = stats.missRate() * 100;
 
                 cacheInfo.clearable = cacheInfo.clearable
-                        && propertyGetter('ootbee-support-tools.cache.invalidating.allowClear', '').toLowerCase() === 'true';
+                        && propertyGetter('ootbee-support-tools.cache.invalidating.clearable', '').toLowerCase() === 'true';
                 break;
             case 'org.alfresco.enterprise.repo.cluster.cache.HazelcastSimpleCache':
                 stats = Packages.org.orderofthebee.addons.support.tools.repo.caches.CacheLookupUtils.getHzSimpleCacheStats(cache);
@@ -161,7 +161,7 @@ function buildCacheInfo(cacheName, cache, allowClearGlobal, propertyGetter)
                 }
 
                 cacheInfo.clearable = cacheInfo.clearable
-                        && propertyGetter('ootbee-support-tools.cache.distributed.allowClear', '').toLowerCase() === 'true';
+                        && propertyGetter('ootbee-support-tools.cache.distributed.clearable', '').toLowerCase() === 'true';
                 break;
             default:
                 // check support of CacheWithMetrics without requiring explicit interface inheritance
@@ -169,22 +169,22 @@ function buildCacheInfo(cacheName, cache, allowClearGlobal, propertyGetter)
                 {
                     mapCacheMetrics(cache.metrics, cacheInfo);
                     cacheInfo.clearable = cacheInfo.clearable
-                            && propertyGetter('ootbee-support-tools.cache.' + cacheInfo.type + '.allowClear',
-                                    propertyGetter('ootbee-support-tools.cache.unknown.allowClear', '')).toLowerCase() === 'true';
+                            && propertyGetter('ootbee-support-tools.cache.' + cacheInfo.type + '.clearable',
+                                    propertyGetter('ootbee-support-tools.cache.unknown.clearable', '')).toLowerCase() === 'true';
                 }
                 else if (alfCacheStats !== undefined && alfCacheStats !== null)
                 {
                     // fallback to Alfresco cache statistics
                     mapCacheMetrics(alfCacheStats, cacheInfo);
                     cacheInfo.clearable = cacheInfo.clearable
-                            && propertyGetter('ootbee-support-tools.cache.' + cacheInfo.type + '.allowClear',
-                                    propertyGetter('ootbee-support-tools.cache.unknown.allowClear', '')).toLowerCase() === 'true';
+                            && propertyGetter('ootbee-support-tools.cache.' + cacheInfo.type + '.clearable',
+                                    propertyGetter('ootbee-support-tools.cache.unknown.clearable', '')).toLowerCase() === 'true';
                 }
                 else
                 {
                     cacheInfo.clearable = cacheInfo.clearable
-                            && propertyGetter('ootbee-support-tools.cache.' + cacheInfo.type + '.allowClear',
-                                    propertyGetter('ootbee-support-tools.cache.unknown.allowClear', '')).toLowerCase() === 'true';
+                            && propertyGetter('ootbee-support-tools.cache.' + cacheInfo.type + '.clearable',
+                                    propertyGetter('ootbee-support-tools.cache.unknown.clearable', '')).toLowerCase() === 'true';
                 }
         }
     }
@@ -241,7 +241,7 @@ function buildCaches()
     cacheInfos = [];
     cacheBeanNames = ctxt.getBeanNamesForType(Packages.org.alfresco.repo.cache.SimpleCache, false, false);
     
-    allowClearGlobal = propertyGetter('ootbee-support-tools.cache.allowClear', '').toLowerCase() === 'true';
+    allowClearGlobal = propertyGetter('ootbee-support-tools.cache.clearable', '').toLowerCase() === 'true';
 
     for (idx = 0; idx < cacheBeanNames.length; idx++)
     {

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/system-information.lib.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/system-information.lib.js
@@ -29,7 +29,7 @@ function buildSystemInformation(){
     ctxt = Packages.org.springframework.web.context.ContextLoader.getCurrentWebApplicationContext();
     globalProperties = ctxt.getBean('global-properties', Packages.java.util.Properties);
     model.globalProperties = globalProperties;
-    model.sensitiveKeys = globalProperties["support-tools.systeminformation.sensitiveKeys"].split(',');
+    model.sensitiveKeys = globalProperties["ootbee-support-tools.systeminformation.sensitiveKeys"].split(',');
 
     model.environmentProperties = Packages.java.lang.System.getenv();
     model.systemProperties = Packages.java.lang.System.getProperties();

--- a/repository/src/main/amp/web/ootbee-support-tools/js/caches.js
+++ b/repository/src/main/amp/web/ootbee-support-tools/js/caches.js
@@ -38,17 +38,43 @@ Admin.addEventListener(window, 'load', function()
 
 (function()
 {
-    AdminCA.setupTables = function()
+    var serviceContext;
+
+    AdminCA.setServiceContext = function setServiceContext(context)
+    {
+        serviceContext = context;
+    };
+
+    AdminCA.setupTables = function setupTables()
     {
         var dataTableConfig;
 
         dataTableConfig = {
             paging : false,
             searching : false,
-            autoWidth : false
+            autoWidth : false,
+            columnDefs : [ {
+                orderable : false,
+                targets : [ 11 ]
+            } ]
         };
 
         $('#caches-table').DataTable(dataTableConfig);
+    };
+
+    AdminCA.clearCache = function clearCache(cacheName)
+    {
+        if (cacheName !== undefined && cacheName !== null)
+        {
+            Admin.request({
+                url : serviceContext + '/ootbee/admin/caches/' + encodeURI(String(cacheName).replace(/\./, '%dot%')) + '/clear',
+                method : 'POST',
+                fnSuccess : function clearCache_success()
+                {
+                    location.reload(true);
+                }
+            });
+        }
     };
 
 })();

--- a/repository/src/main/amp/web/ootbee-support-tools/js/caches.js
+++ b/repository/src/main/amp/web/ootbee-support-tools/js/caches.js
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2016 Axel Faust
- * Copyright (C) 2016 Order of the Bee
+ * Copyright (C) 2016, 2017 Axel Faust
+ * Copyright (C) 2016, 2017 Order of the Bee
  * 
  * This file is part of Community Support Tools
  * 
@@ -20,7 +20,7 @@
  */
 /*
  * Linked to Alfresco Copyright
- * (C) 2005-2016 Alfresco Software Limited.
+ * (C) 2005-2017 Alfresco Software Limited.
  */
 
 /* global Admin: false, $: false*/


### PR DESCRIPTION
### CHECKLIST

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR adds the basic ability to clear individual Repository-tier caches. A system administrator can configure if cache clearing should be disallowed (globally or for general types of caches). The PR includes default configurations for default out-of-the-box caches (based on 5.2) about which caches technically should be considered clearable (e.g. that should not affect the Alfresco system irrecoverably).
The current functionality simply reloads the page to re-fetch the updated statistics of the affected cache and all other caches. In a near-future improvement we should make the cache list reloadable (will create a new issue for that).

As an aside this PR includes a minor correction of a configuration property that did not yet include the proper unique prefix "ootbee-support-tools" to ensure differentiation from Alfresco Support Tools.

Fixes #70