### PR TITLE
(#86) Avoid template error when JVM does not support boot classpath

### DIFF
--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/system-information.get.html.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/system-information.get.html.ftl
@@ -1,6 +1,6 @@
 <#-- 
-Copyright (C) 2016 Axel Faust / Markus Joos / Jens Goldhammer
-Copyright (C) 2016 Order of the Bee
+Copyright (C) 2016, 2017 Jens Goldhammer
+Copyright (C) 2016, 2017 Order of the Bee
 
 This file is part of Community Support Tools
 
@@ -18,7 +18,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
 
 Linked to Alfresco
-Copyright (C) 2005-2016 Alfresco Software Limited.
+Copyright (C) 2005-2017 Alfresco Software Limited.
  
   -->
   

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/system-information.get.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/system-information.get.js
@@ -2,8 +2,8 @@
 <import resource="classpath:alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/system-information.lib.js">
 
 /**
- * Copyright (C) 2016 Axel Faust / Markus Joos
- * Copyright (C) 2016 Order of the Bee
+ * Copyright (C) 2016, 2017 Jens Goldhammer
+ * Copyright (C) 2016, 2017 Order of the Bee
  *
  * This file is part of Community Support Tools
  *
@@ -22,7 +22,7 @@
  */
 /*
  * Linked to Alfresco
- * Copyright (C) 2005-2016 Alfresco Software Limited.
+ * Copyright (C) 2005-2017 Alfresco Software Limited.
  */
 
 buildSystemInformation();

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/system-information.lib.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/system-information.lib.js
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2016 Axel Faust / Markus Joos
- * Copyright (C) 2016 Order of the Bee
+ * Copyright (C) 2016, 2017 Jens Goldhammer
+ * Copyright (C) 2016, 2017 Order of the Bee
  *
  * This file is part of Community Support Tools
  *
@@ -19,11 +19,12 @@
  */
 /*
  * Linked to Alfresco
- * Copyright (C) 2005-2016 Alfresco Software Limited.
+ * Copyright (C) 2005-2017 Alfresco Software Limited.
  */
 
 /* exported buildSystemInformation */
-function buildSystemInformation(){
+function buildSystemInformation()
+{
     var ctxt, managementFactory, runtime, globalProperties, duration, prettyUptime;
 
     ctxt = Packages.org.springframework.web.context.ContextLoader.getCurrentWebApplicationContext();
@@ -37,8 +38,13 @@ function buildSystemInformation(){
     managementFactory = Packages.java.lang.management.ManagementFactory;
     runtime = managementFactory.getRuntimeMXBean();
 
-    if (runtime.isBootClassPathSupported()){
+    if (runtime.isBootClassPathSupported())
+    {
         model.bootClassPath = runtime.getBootClassPath().split(Packages.java.io.File.pathSeparator);
+    }
+    else
+    {
+        model.bootClassPath = [];
     }
 
     model.javaArguments = runtime.getInputArguments();

--- a/repository/src/main/amp/web/ootbee-support-tools/js/system-information.js
+++ b/repository/src/main/amp/web/ootbee-support-tools/js/system-information.js
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2016 Axel Faust / Markus Joos / Jens Goldhammer
- * Copyright (C) 2016 Order of the Bee
+ * Copyright (C) 2016, 2017 Jens Goldhammer
+ * Copyright (C) 2016, 2017 Order of the Bee
  * 
  * This file is part of Community Support Tools
  * 
@@ -20,7 +20,7 @@
  */
 /*
  * Linked to Alfresco Copyright
- * (C) 2005-2016 Alfresco Software Limited.
+ * (C) 2005-2017 Alfresco Software Limited.
  */
 
 /* global Admin: false, $: false*/


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

Correct an issue with an uninitialised model variable by defaulting it to an empty array if the JVM does not support a boot classpath. In addition I have also corrected the copyright attribution to recognize @jgoldhammer (he had used the default header in the original PR).

### RELATED INFORMATION

Fixes #86