### PR TITLE
Remove default character limit and fix double encoding in Test Transform

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -55,6 +55,22 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src\main\resources</directory>
+                <filtering>true</filtering>
+            </resource>
+            <resource>
+                <directory>src\main\amp</directory>
+                <targetPath>${project.build.directory}/amp</targetPath>
+                <filtering>true</filtering>
+                <excludes>
+                    <exclude>**/.jshintrc</exclude>
+                    <exclude>**/.jshintignore</exclude>
+                </excludes>
+            </resource>
+        </resources>
+
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/admin-template.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/admin-template.ftl
@@ -1,6 +1,6 @@
 <#-- 
-Copyright (C) 2016 Axel Faust / Markus Joos
-Copyright (C) 2016 Order of the Bee
+Copyright (C) 2016. 2017 Axel Faust / Markus Joos
+Copyright (C) 2016. 2017 Order of the Bee
 
 This file is part of Community Support Tools
 
@@ -18,7 +18,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
 
 Linked to Alfresco
-Copyright (C) 2005-2016 Alfresco Software Limited.
+Copyright (C) 2005-2017 Alfresco Software Limited.
  
   -->
 
@@ -26,8 +26,11 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
    ADMIN TEMPLATE MACROS
    
    This file is mostly a 1:1 copy of the Alfresco original admin-template.ftl
-   The main change is the externalization of inline JavaScript and the ability
-   to load custom JSS and CSS files
+   The main changes are
+   - externalization of inline JavaScript
+   - the ability to load custom JSS and CSS files
+   - optionality of maxlength on form fields instead of hard default of 255 characters
+   - option to specify rows/cols for textarea
 -->
 <#--
    Template outer "page" macro.
@@ -284,27 +287,27 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
 </#macro>
 
 <#-- Label and text input field -->
-<#macro text name label="" description="" value="" maxlength=255 id="" style="" controlStyle="" valueStyle="" placeholder="" escape=true>
+<#macro text name label="" description="" value="" maxlength="" id="" style="" controlStyle="" valueStyle="" placeholder="" escape=true>
    <div class="control text"<#if style?has_content> style="${style?html}"</#if>>
       <#if label?has_content><span class="label">${label?html}:</span></#if>
-      <span class="value"<#if valueStyle?has_content> style="${valueStyle?html}"</#if>><input <#if id?has_content>id="${id?html}"</#if> name="${name?html}" value="${value?html}" maxlength="${maxlength?c}" tabindex="0" <#if placeholder?has_content>placeholder="${placeholder?html}"</#if> <#if controlStyle?has_content>style="${controlStyle?html}"</#if>/></span>
+      <span class="value"<#if valueStyle?has_content> style="${valueStyle?html}"</#if>><input <#if id?has_content>id="${id?html}"</#if> name="${name?html}" value="${value?html}" <#if maxlength?is_number>maxlength="${maxlength?c}"</#if> tabindex="0" <#if placeholder?has_content>placeholder="${placeholder?html}"</#if> <#if controlStyle?has_content>style="${controlStyle?html}"</#if>/></span>
       <#if description?has_content><span class="description"><#if escape>${description?html}<#else>${description}</#if></span></#if>
    </div>
 </#macro>
-<#macro attrtext attribute label=attribute.name description="" maxlength=255 id="" style="" controlStyle="" valueStyle="" placeholder="" escape=true>
+<#macro attrtext attribute label=attribute.name description="" maxlength="" id="" style="" controlStyle="" valueStyle="" placeholder="" escape=true>
    <@text name=attribute.qname label=label description=description value=cvalue(attribute.type, attribute.value) maxlength=maxlength id=id style=style controlStyle=controlStyle valueStyle=valueStyle placeholder=placeholder escape=escape />
 </#macro>
 
 <#-- Label and password input field -->
-<#macro password id name label="" description="" value="" maxlength=255 style="" controlStyle="" visibilitytoggle=false>
+<#macro password id name label="" description="" value="" maxlength="" style="" controlStyle="" visibilitytoggle=false>
    <div class="control text password"<#if style?has_content> style="${style?html}"</#if>>
       <#if label?has_content><span class="label">${label?html}:</span></#if>
-      <span class="value"><input id="${id?html}" name="${name?html}" value="${value?html}" maxlength="${maxlength?c}" type="password" tabindex="0" <#if controlStyle?has_content>style="${controlStyle?html}"</#if>/></span>
+      <span class="value"><input id="${id?html}" name="${name?html}" value="${value?html}" <#if maxlength?is_number>maxlength="${maxlength?c}"</#if> type="password" tabindex="0" <#if controlStyle?has_content>style="${controlStyle?html}"</#if>/></span>
       <#if visibilitytoggle><@button label=msg("admin-console.password.show")?html onclick="Admin.togglePassword('${id?html}', this);" /></#if>
       <#if description?has_content><span class="description">${description?html}</span></#if>
    </div>
 </#macro>
-<#macro attrpassword attribute label=attribute.name id=attribute.qname description="" maxlength=255 style="" controlStyle="" visibilitytoggle=false populatevalue=false>
+<#macro attrpassword attribute label=attribute.name id=attribute.qname description="" maxlength="" style="" controlStyle="" visibilitytoggle=false populatevalue=false>
    <#if populatevalue>
    <@password name=attribute.qname label=label id=id description=description value=cvalue(attribute.type, attribute.value) maxlength=maxlength style=style controlStyle=controlStyle visibilitytoggle=visibilitytoggle />
    <#else>
@@ -313,15 +316,15 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
 </#macro>
 
 <#-- Label and text area field -->
-<#macro textarea name label="" description="" value="" maxlength=255 id="" style="" controlStyle="">
+<#macro textarea name label="" description="" value="" maxlength="" id="" style="" controlStyle="" rows="" cols="">
    <div class="control textarea"<#if style?has_content> style="${style?html}"</#if>>
       <#if label?has_content><span class="label">${label?html}:</span></#if>
-      <span class="value"><textarea <#if id?has_content>id="${id?html}"</#if> name="${name?html}" maxlength="${maxlength?c}" tabindex="0" <#if controlStyle?has_content>style="${controlStyle?html}"</#if>>${value?html}</textarea></span>
+      <span class="value"><textarea <#if id?has_content>id="${id?html}"</#if> name="${name?html}" <#if rows?is_number>rows="${rows?c}"</#if> <#if rows?is_number>cols="${cols?c}"</#if> <#if maxlength?is_number>maxlength="${maxlength?c}"</#if> tabindex="0" <#if controlStyle?has_content>style="${controlStyle?html}"</#if>>${value?html}</textarea></span>
       <#if description?has_content><span class="description">${description?html}</span></#if>
    </div>
 </#macro>
-<#macro attrtextarea attribute label=attribute.name description="" maxlength=255 id="" style="" controlStyle="">
-   <@textarea name=attribute.qname label=label description=description value=cvalue(attribute.type, attribute.value) maxlength=maxlength id=id style=style controlStyle=controlStyle />
+<#macro attrtextarea attribute label=attribute.name description="" maxlength="" id="" style="" controlStyle="" rows="" cols="">
+   <@textarea name=attribute.qname label=label description=description value=cvalue(attribute.type, attribute.value) maxlength=maxlength id=id style=style controlStyle=controlStyle rows=rows cols=cols />
 </#macro>
 
 <#-- Label and checkbox boolean field -->

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/test-transform-details.get.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/test-transform-details.get.js
@@ -2,8 +2,8 @@
 <import resource="classpath:alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/test-transform.lib.js">
 
 /**
- * Copyright (C) 2016 Axel Faust / Markus Joos
- * Copyright (C) 2016 Order of the Bee
+ * Copyright (C) 2016, 2017 Axel Faust / Markus Joos
+ * Copyright (C) 2016, 2017 Order of the Bee
  *
  * This file is part of Community Support Tools
  *
@@ -22,7 +22,7 @@
  */
 /*
  * Linked to Alfresco
- * Copyright (C) 2005-2016 Alfresco Software Limited.
+ * Copyright (C) 2005-2017 Alfresco Software Limited.
  */
 
 // operation should be reflected

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/test-transform.get.html.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/test-transform.get.html.ftl
@@ -1,6 +1,6 @@
 <#-- 
-Copyright (C) 2016 Axel Faust / Markus Joos
-Copyright (C) 2016 Order of the Bee
+Copyright (C) 2016, 2017 Axel Faust / Markus Joos
+Copyright (C) 2016, 2017 Order of the Bee
 
 This file is part of Community Support Tools
 
@@ -18,7 +18,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
 
 Linked to Alfresco
-Copyright (C) 2005-2016 Alfresco Software Limited.
+Copyright (C) 2005-2017 Alfresco Software Limited.
  
   -->
 
@@ -51,10 +51,10 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
         <p class="info">${msg("test-transform.setProperties.description")?html}</p>
     </div>
 	<div class="column-left">
-        <@textarea name="setProperties" label=msg("test-transform.setProperties.property") description=msg("test-transform.setProperties.property.description") maxlength=255 id="setProperties" />
+        <@textarea name="setProperties" label=msg("test-transform.setProperties.property") description=msg("test-transform.setProperties.property.description") id="setProperties" />
     </div>
 	<div class="column-right">
-        <@button label=msg("test-transform.setProperties.button") onclick="AdminTT.showInDialog('setProperties', encodeURIComponent(el('setProperties').value));"/>
+        <@button label=msg("test-transform.setProperties.button") onclick="AdminTT.showInDialog('setProperties', el('setProperties').value);"/>
 	</div>
 
 	<div class="column-full">
@@ -62,10 +62,10 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
         <p class="info">${msg("test-transform.removeProperties.description")?html}</p>
     </div>
     <div class="column-left">
-        <@textarea name="removeProperties" label=msg("test-transform.removeProperties.property") maxlength=255 id="removeProperties" />
+        <@textarea name="removeProperties" label=msg("test-transform.removeProperties.property") id="removeProperties" />
     </div>
     <div class="column-right">
-        <@button label=msg("test-transform.removeProperties.button") onclick="AdminTT.showInDialog('removeProperties', encodeURIComponent(el('removeProperties').value));"/>
+        <@button label=msg("test-transform.removeProperties.button") onclick="AdminTT.showInDialog('removeProperties', el('removeProperties').value);"/>
     </div>
 
     <div class="column-full">  

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/test-transform.get.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/test-transform.get.js
@@ -2,8 +2,8 @@
 <import resource="classpath:alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/test-transform.lib.js">
 
 /**
- * Copyright (C) 2016 Axel Faust / Markus Joos
- * Copyright (C) 2016 Order of the Bee
+ * Copyright (C) 2016, 2017 Axel Faust / Markus Joos
+ * Copyright (C) 2016, 2017 Order of the Bee
  *
  * This file is part of Community Support Tools
  *
@@ -22,7 +22,7 @@
  */
 /*
  * Linked to Alfresco
- * Copyright (C) 2005-2016 Alfresco Software Limited.
+ * Copyright (C) 2005-2017 Alfresco Software Limited.
  */
 
 buildTransformerNames();

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/test-transform.lib.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/test-transform.lib.js
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2016 Axel Faust / Markus Joos
- * Copyright (C) 2016 Order of the Bee
+ * Copyright (C) 2016, 2017 Axel Faust / Markus Joos
+ * Copyright (C) 2016, 2017 Order of the Bee
  *
  * This file is part of Community Support Tools
  *
@@ -19,7 +19,7 @@
  */
 /*
  * Linked to Alfresco
- * Copyright (C) 2005-2016 Alfresco Software Limited.
+ * Copyright (C) 2005-2017 Alfresco Software Limited.
  */
 
 function buildTransformerNames()

--- a/repository/src/main/amp/web/ootbee-support-tools/js/test-transform.js
+++ b/repository/src/main/amp/web/ootbee-support-tools/js/test-transform.js
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2016 Axel Faust / Markus Joos
- * Copyright (C) 2016 Order of the Bee
+ * Copyright (C) 2016, 2017 Axel Faust / Markus Joos
+ * Copyright (C) 2016, 2017 Order of the Bee
  * 
  * This file is part of Community Support Tools
  * 
@@ -20,7 +20,7 @@
  */
 /*
  * Linked to Alfresco Copyright
- * (C) 2005-2016 Alfresco Software Limited.
+ * (C) 2005-2017 Alfresco Software Limited.
  */
 
 /* global Admin: false */

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -65,6 +65,22 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src\main\resources</directory>
+                <filtering>true</filtering>
+            </resource>
+            <resource>
+                <directory>src\main\amp</directory>
+                <targetPath>${project.build.directory}/amp</targetPath>
+                <filtering>true</filtering>
+                <excludes>
+                    <exclude>**/.jshintrc</exclude>
+                    <exclude>**/.jshintignore</exclude>
+                </excludes>
+            </resource>
+        </resources>
+
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
### CHECKLIST
- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION
This PR addresses two issues raised with regards to the Test Transform tool. The arbitrary default limitation of any form field to 255 characters of input has been removed (still possible to specify via parameter in macro call), the textarea macro has been improved with the option to specify cols/rows as parameters, and instances of double URL encoding of parameters for a form submission to the details web script have been removed as well.

A minor side-change that was done is to configure the POM(s) to keep in-place jshint configuration files out of the resulting AMP artifact.

### RELATED INFORMATION
Fixes #89, #90