### PR TITLE
Switch log snapshot from file path reference to UUID

### DIFF
--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-complete.get.desc.xml
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-complete.get.desc.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!-- This web script really should be a POST/DELETE, but needs to be GET to work with browser UI -->
 <webscript>
-	<shortname>Log4J Snapshot</shortname>
-	<description>Finish log snapshot and shows it</description>
-	<url>/ootbee/admin/log4j-snapshot-complete/{path}</url>
+	<shortname>Log4J Settings - Log File - Close Snapshot</shortname>
+	<description>Closes (deregisters) a snapshot Log4J appender and retrieves the contents of the associated log file</description>
+	<url>/ootbee/admin/log4j-snapshots/{snapshotUUID}</url>
 	<authentication>admin</authentication>
 	<lifecycle>internal</lifecycle>
 	<transaction>none</transaction>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-create.post.desc.xml
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-create.post.desc.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <webscript>
     <shortname>Log4J Settings - Log File - Create Snapshot</shortname>
-    <description>Accesses a specific Log4J log file</description>
-    <url>/ootbee/admin/log4j-snapshot-create</url>
+    <description>Creates a snapshot Log4J appender and log file</description>
+    <url>/ootbee/admin/log4j-snapshots</url>
     <authentication>admin</authentication>
     <format default="json"/>
     <lifecycle>internal</lifecycle>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-create.post.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-create.post.js
@@ -24,4 +24,4 @@
  * Copyright (C) 2005-2017 Alfresco Software Limited.
  */
 
-model.snapshotLogFile = createSnapshot();
+model.snapshotUUID = createSnapshot();

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-create.post.json.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-create.post.json.ftl
@@ -22,8 +22,8 @@ Linked to Alfresco
 Copyright (C) 2005-2017 Alfresco Software Limited.
  
 -->
-
+<#escape x as jsonUtils.encodeJSONString(x)>
 {
-    "snapshotLogFile": "${snapshotLogFile}"
+    "snapshotUUID": "${snapshotUUID}"
 }
-</#compress>
+</#escape></#compress>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j.lib.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j.lib.js
@@ -444,11 +444,9 @@ function getLoggersToSnapshot()
 /* exported createSnapshot */
 function createSnapshot()
 {
-	var snapshotLogFile, logLayout, snapshotAppender, loggers;
+	var snapshotAppender, loggers;
 	
-	snapshotLogFile = Packages.org.alfresco.util.TempFileProvider.createTempFile("ootbee-support-tools-snapshot", ".log");
-	logLayout = new Packages.org.apache.log4j.PatternLayout('%d{yyyy-MM-dd} %d{ABSOLUTE} %-5p [%c] [%t] %m%n');		
-	snapshotAppender = new Packages.org.orderofthebee.addons.support.tools.repo.TemporaryFileAppender(logLayout, snapshotLogFile);
+	snapshotAppender = new Packages.org.orderofthebee.addons.support.tools.repo.TemporaryFileAppender('ootbee-support-tools-snapshot-');
 	loggers = getLoggersToSnapshot();
 	loggers.forEach(
 	    function createSnapshot_connectLoggerAndAppender(logger)
@@ -457,19 +455,18 @@ function createSnapshot()
 	    }
     );
 	
-	return snapshotLogFile;
+	return snapshotAppender.appenderUUID;
 }
 
 /* exported logSnapshotLapMessage */
 function logSnapshotLapMessage(message) {
-    var root, clazz, level, lapLogger;
+    var lapLogger, level;
 
-    root = Packages.org.apache.log4j.Logger.getRootLogger();
+    // Fake logger that does not correspond to any class-based logger
+    lapLogger = Packages.org.apache.log4j.Logger.getLogger('org.orderofthebee.addons.support.tools.repo.logSnapshotLap');
+
+    // ensure level is enabled (in case someone reconfigured logger) and log
     level = Packages.org.apache.log4j.Level.INFO;
-    // Fake logger that produces a good log message with the Alfresco default log format
-    clazz = 'org.orderofthebee.addons.support.tools.repo.logSnapshotLap';
-    lapLogger = root.getLogger(clazz);
     lapLogger.setLevel(level);
-
     lapLogger.log(level, message);
 }

--- a/repository/src/main/amp/web/ootbee-support-tools/js/log-settings.js
+++ b/repository/src/main/amp/web/ootbee-support-tools/js/log-settings.js
@@ -35,7 +35,7 @@ var AdminLS = AdminLS || {};
     var KEYCODE_ENTER = 13;
     var KEYCODE_ESC = 27;
 
-    var serviceContext, snapshotLogFile, snapshotLapNumber;
+    var serviceContext, snapshotUUID, snapshotLapNumber;
     
     AdminLS.setServiceContext = function setServiceContext(context)
     {
@@ -58,13 +58,13 @@ var AdminLS = AdminLS || {};
     AdminLS.startLogSnapshot = function startLogSnapshot()
     {
         Admin.request({
-          url : serviceContext + '/ootbee/admin/log4j-snapshot-create',
-          method : 'GET',
+          url : serviceContext + '/ootbee/admin/log4j-snapshots',
+          method : 'POST',
           fnSuccess : function startLogSnapshot_success(res)
           {
               if (res.responseJSON)
               {
-                  snapshotLogFile = res.responseJSON.snapshotLogFile;
+                  snapshotUUID = res.responseJSON.snapshotUUID;
                   document.getElementById("startLogSnapshot").style.display = 'none';
                   document.getElementById("stopLogSnapshot").style.display = 'inline';
                   document.getElementById("lapLogSnapshot").style.display = 'inline';
@@ -78,11 +78,12 @@ var AdminLS = AdminLS || {};
     
     AdminLS.stopLogSnapshot = function stopLogSnapshot()
     {
-        window.open(serviceContext + '/ootbee/admin/log4j-snapshot-complete/'+snapshotLogFile+'?a=true','_blank');
+        window.open(serviceContext + '/ootbee/admin/log4j-snapshots/' + encodeURIComponent(snapshotUUID) + '?a=true', '_blank');
         document.getElementById("startLogSnapshot").style.display = 'inline';
         document.getElementById("stopLogSnapshot").style.display = 'none';
         document.getElementById("lapLogSnapshot").style.display = 'none';
         document.getElementById("lapMessageLogSnapshot").style.display = 'none';
+        snapshotUUID = null;
     };
 
     AdminLS.lapLogSnapshot = function lapLogSnapshot()


### PR DESCRIPTION
### CHECKLIST
- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION
This PR changes the way the log snapshot feature deals with identifying a particular snapshot session. Instead of using the full file path for reference (and having to validate it), a generic UUID is now being used. This avoids any encoding issues e.g. when the file path may contain backslashes instead of regular slashes.
In addition to this change, various smaller aspects have also been addressed:
* move the temporary file handling into the temporary appender itself
* move the appender layout default into the temporary appender itself
* switch the snapshot start web script to use proper HTTP method (POST) - note that completion web script could not be switched to proper HTTP method as it is required to be a GET for use in the web UI

### RELATED INFORMATION
Fixes #91

Note: By editing the Java-backed web scripts my formatter / auto-save rules have been applied to yield a consistent style. We still have #83 to further consolidate, document style conventions and potentially provide tools to achieve consistent code style.