### PR TITLE
Share Log4J Settings - Avoid clearance of log entry table

### DIFF
--- a/share/src/main/amp/web/ootbee-support-tools/list/LogList.js
+++ b/share/src/main/amp/web/ootbee-support-tools/list/LogList.js
@@ -176,6 +176,11 @@ define([ 'dojo/_base/declare', 'alfresco/lists/AlfList', 'dojo/_base/lang', 'alf
                         this.pendingLoadRequest = false;
                         this.loadData();
                     }
+                    else if (payload.response.events.length === 0)
+                    {
+                        this.hideLoadingMessage();
+                        this.alfPublish(this.requestFinishedTopic, {});
+                    }
                     else
                     {
                         this.currentData = {};


### PR DESCRIPTION
- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR addresses bug #98 wherein the Share-tier feature of log tailing will clear the log entry table when a single load retrieved zero (new) log entries.

### RELATED INFORMATION

Fixes #98