### PR TITLE
Prepare 1.0.0.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.orderofthebee.support-tools</groupId>
     <artifactId>support-tools-parent</artifactId>
-    <version>1.0.0.0-SNAPSHOT</version>
+    <version>1.0.0.0</version>
     <packaging>pom</packaging>
 
     <name>OOTBee Support Tools - Parent</name>
@@ -208,6 +208,26 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>de.acosix.maven</groupId>
+                    <artifactId>jshint-maven-plugin</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <sourceDirectory>${project.basedir}/src/main</sourceDirectory>
+                        <includes>
+                            <include>amp/**/*.js</include>
+                        </includes>
+                        <checkstyleReportFile>js-checkstyle.xml</checkstyleReportFile>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>jshint</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <version>1.6.7</version>
@@ -216,6 +236,68 @@
                         <serverId>ossrh</serverId>
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.alfresco.maven.plugin</groupId>
+                                        <artifactId>alfresco-maven-plugin</artifactId>
+                                        <versionRange>[0.0,)</versionRange>
+                                        <goals>
+                                            <goal>set-version</goal>
+                                            <goal>refresh-share</goal>
+                                            <goal>refresh-repo</goal>
+                                            <goal>refresh</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute>
+                                            <runOnIncremental>true</runOnIncremental>
+                                            <runOnConfiguration>true</runOnConfiguration>
+                                        </execute>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.codehaus.mojo</groupId>
+                                        <artifactId>build-helper-maven-plugin</artifactId>
+                                        <versionRange>[1.10,)</versionRange>
+                                        <goals>
+                                            <goal>add-test-resource</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute>
+                                            <runOnIncremental>true</runOnIncremental>
+                                            <runOnConfiguration>true</runOnConfiguration>
+                                        </execute>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>de.acosix.maven</groupId>
+                                        <artifactId>jshint-maven-plugin</artifactId>
+                                        <versionRange>[1.0.0,)</versionRange>
+                                        <goals>
+                                            <goal>jshint</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute>
+                                            <runOnIncremental>true</runOnIncremental>
+                                            <runOnConfiguration>true</runOnConfiguration>
+                                        </execute>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
             </plugins>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.orderofthebee.support-tools</groupId>
         <artifactId>support-tools-parent</artifactId>
-        <version>1.0.0.0-SNAPSHOT</version>
+        <version>1.0.0.0</version>
     </parent>
 
     <artifactId>support-tools-repo</artifactId>
@@ -94,12 +94,7 @@
             <plugin>
                 <groupId>de.acosix.maven</groupId>
                 <artifactId>jshint-maven-plugin</artifactId>
-                <version>1.0.0</version>
                 <configuration>
-                    <sourceDirectory>${project.basedir}/src/main</sourceDirectory>
-                    <includes>
-                        <include>amp/**/*.js</include>
-                    </includes>
                     <excludes>
                         <exclude>amp/config/alfresco/templates/webscripts/**/*.get.js</exclude>
                         <exclude>amp/config/alfresco/templates/webscripts/**/*.delete.js</exclude>
@@ -113,7 +108,6 @@
                         <exclude>amp/web/ootbee-support-tools/js/dataTables.buttons.min.js</exclude>
                         <exclude>amp/web/ootbee-support-tools/js/dataTables.bootstrap4.min.js</exclude>
                     </excludes>
-                    <checkstyleReportFile>js-checkstyle.xml</checkstyleReportFile>
                 </configuration>
                 <executions>
                     <execution>

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.orderofthebee.support-tools</groupId>
         <artifactId>support-tools-parent</artifactId>
-        <version>1.0.0.0-SNAPSHOT</version>
+        <version>1.0.0.0</version>
     </parent>
 
     <artifactId>support-tools-share</artifactId>
@@ -127,26 +127,36 @@
             <plugin>
                 <groupId>de.acosix.maven</groupId>
                 <artifactId>jshint-maven-plugin</artifactId>
-                <version>1.0.0</version>
-                <configuration>
-                    <sourceDirectory>${project.basedir}/src/main</sourceDirectory>
-                    <includes>
-                        <include>amp/**/*.js</include>
-                    </includes>
-                    <checkstyleReportFile>js-checkstyle.xml</checkstyleReportFile>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>jshint</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>yuicompressor-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compress-js</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>compress</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/webscripts/**</exclude>
+                                <exclude>**/webscripts/**</exclude>
+                                <exclude>**/site-webscripts/**</exclude>
+                                <exclude>**/*.lib.js</exclude>
+                                <exclude>**/*.css</exclude>
+                                <!-- exclude Aikau resources (minified at runtime) -->
+                                <exclude>web/ootbee-support-tools/**/*.js</exclude>
+                                <exclude>web/ootbee-support-tools/**/*.css</exclude>
+                            </excludes>
+                            <sourceDirectory>src/main/amp</sourceDirectory>
+                            <outputDirectory>${project.build.directory}/amp</outputDirectory>
+                            <excludeResources>true</excludeResources>
+                            <jswarn>false</jswarn>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
 


### PR DESCRIPTION
- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR updates the project in preparation of a 1.0.0.0 release. The changes included are merely related to the POM setup. The following changes are made:
* update version numbers
* consolidate JSHint plugin configuration
* add missing Eclipse lifecycle mappings for JSHint and build-helper
* exclude Aikau resources from minification (done at runtime)

This PR will conclude work on the 1.0.0.0 milestone, so that we can start working on new features from our backlog.