### PR TITLE
README should reflect that 1.0.0.0 version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In order to use a pre-built SNAPSHOT artifact published to the Open Source Sonat
 <dependency>
     <groupId>org.orderofthebee.support-tools</groupId>
     <artifactId>support-tools-repo</artifactId>
-    <version>0.0.1.0-SNAPSHOT</version>
+    <version>1.0.0.0</version>
     <type>amp</type>
 </dependency>
 ```
@@ -74,7 +74,7 @@ For Alfresco SDK 3 beta users:
     <moduleDependency>
         <groupId>org.orderofthebee.support-tools</groupId>
         <artifactId>support-tools-repo</artifactId>
-        <version>0.0.1.0-SNAPSHOT</version>
+        <version>1.0.0.0</version>
         <type>amp</type>
     </moduleDependency>
 </platformModules>
@@ -88,7 +88,7 @@ The Admin Tools added to the Share user interface are built on Aikau. We recomme
 <dependency>
     <groupId>org.orderofthebee.support-tools</groupId>
     <artifactId>support-tools-share</artifactId>
-    <version>0.0.1.0-SNAPSHOT</version>
+    <version>1.0.0.0</version>
     <type>amp</type>
 </dependency>
 <dependency>
@@ -130,7 +130,7 @@ For Alfresco SDK 3 beta users:
     <moduleDependency>
         <groupId>org.orderofthebee.support-tools</groupId>
         <artifactId>support-tools-share</artifactId>
-        <version>0.0.1.0-SNAPSHOT</version>
+        <version>1.0.0.0</version>
         <type>amp</type>
     </moduleDependency>
 </shareModules>

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>${alfresco.groupId}</groupId>
                 <artifactId>aikau</artifactId>
-                <version>1.0.101</version>
+                <version>1.0.103</version>
                 <!-- we require user to pick the Aikau version they want to use - we just state we build and test against this version -->
                 <scope>provided</scope>
                 <exclusions>


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [X] There aren't existing pull requests attempting to address the issue mentioned here
- [X] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

The latest version on Maven Central is 1.0.0.0. Our README still points people at 0.0.1.0-SNAPSHOT. This simply updates the README to reflect the latest version available for use.