### PR TITLE
Exclude many unnecessary transitive Maven dependencies

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -23,6 +23,54 @@
         <dependency>
             <groupId>${alfresco.groupId}</groupId>
             <artifactId>alfresco-remote-api</artifactId>
+            <exclusions>
+               <!-- exclude transitive dependencies not relevant to this addon's purpose (some are even not available any more) -->
+               <!-- the following addresses either completely irrelevant groups (e.g. openoffice) or ones we don't require (yet) with substantial transitive dependency tails -->
+               <exclusion>
+                  <groupId>org.springframework.social</groupId>
+                  <artifactId>*</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>org.apache.chemistry.opencmis</groupId>
+                  <artifactId>*</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>com.google.gdata</groupId>
+                  <artifactId>*</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>com.fasterxml.jackson.core</groupId>
+                  <artifactId>*</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>org.apache.poi</groupId>
+                  <artifactId>*</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>org.apache.pdfbox</groupId>
+                  <artifactId>*</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>org.apache.tika</groupId>
+                  <artifactId>*</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>org.openoffice</groupId>
+                  <artifactId>*</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>com.artofsolving</groupId>
+                  <artifactId>*</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>com.drewnoakes</groupId>
+                  <artifactId>*</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>org.codehaus.groovy</groupId>
+                  <artifactId>*</artifactId>
+               </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -46,7 +46,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
 
@@ -71,6 +70,11 @@
                 <exclusion>
                     <groupId>org.alfresco.surf</groupId>
                     <artifactId>spring-surf-api</artifactId>
+                </exclusion>
+                <!-- exclude transitive dependencies not relevant to this addon's purpose -->
+                <exclusion>
+                    <groupId>org.apache.chemistry.opencmis</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR updates the POMs for the Repository and Share sub-modules to exclude various transitive dependencies that are not required for the purpose of this addon. At least one of these depenencies has already caused issues with building the addon for members of the community (#118) since the non-release artifact referenced by Alfresco distribution POMs is no longer accessible on Maven Central and has not been curated via artifacts.alfresco.com.

### RELATED INFORMATION

Fixes #118