### PR TITLE
Add config redirection in Caches tool

### DIFF
--- a/repository/src/main/amp/config/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
+++ b/repository/src/main/amp/config/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
@@ -7,6 +7,19 @@ ootbee-support-tools.cache.invalidating.clearable=true
 ootbee-support-tools.cache.distributed.clearable=true
 ootbee-support-tools.cache.unknown.clearable=false
 
+# define cache name mappings
+# some caches are inconsistent with regards to the final name and the name used to lookup config during setup
+# this is due to a mismatch of bean name and constructor-provided cache name
+# constructor-provided cache name is used for config lookup
+# bean name overrides that name so our code can never obtain the original constructor-provided name
+# this maps the final name back to the name used for config lookup
+cache.propertyClassSharedCache.configCacheName=propertyClassCache
+cache.propertyValueSharedCache.configCacheName=propertyValueCache
+
+# javascript-console also has a mismatch due to code to manage compatibility with different Alfresco versions
+cache.cache.jsConsoleOutput.configCacheName=jsConsoleOutput
+cache.cache.jsConsoleResult.configCacheName=jsConsoleResult
+
 # define all the caches that we consider clearable without breaking Alfresco
 cache.propertyValueCache.clearable=true
 cache.propertyClassCache.clearable=true

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/admin-template.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/admin-template.ftl
@@ -1,6 +1,6 @@
 <#-- 
-Copyright (C) 2016. 2017 Axel Faust / Markus Joos
-Copyright (C) 2016. 2017 Order of the Bee
+Copyright (C) 2016 - 2018 Axel Faust / Markus Joos
+Copyright (C) 2016 - 2018 Order of the Bee
 
 This file is part of Community Support Tools
 
@@ -18,7 +18,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
 
 Linked to Alfresco
-Copyright (C) 2005-2017 Alfresco Software Limited.
+Copyright (C) 2005-2018 Alfresco Software Limited.
  
   -->
 
@@ -155,7 +155,7 @@ Copyright (C) 2005-2017 Alfresco Software Limited.
    </div>
    
    <div class="footer">
-      Alfresco Software, Inc. &copy; 2005-2016 All rights reserved.
+      Alfresco Software, Inc. &copy; 2005-2018 All rights reserved.
    </div>
    
 <#else>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.js
@@ -2,8 +2,8 @@
 <import resource="classpath:alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js">
 
 /**
- * Copyright (C) 2017 Axel Faust
- * Copyright (C) 2017 Order of the Bee
+ * Copyright (C) 2016 - 2018 Axel Faust
+ * Copyright (C) 2016 - 2018 Order of the Bee
  *
  * This file is part of Community Support Tools
  *
@@ -22,7 +22,7 @@
  */
 /*
  * Linked to Alfresco
- * Copyright (C) 2005-2017 Alfresco Software Limited.
+ * Copyright (C) 2005-2018 Alfresco Software Limited.
  */
 
 resetCache(String(url.templateArgs.cache).replace(/%dot%/g, '.'));

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.json.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.json.ftl
@@ -1,7 +1,7 @@
 <#compress>
 <#-- 
-Copyright (C) 2017 Axel Faust / Markus Joos
-Copyright (C) 2017 Order of the Bee
+Copyright (C) 2016 - 2018 Axel Faust / Markus Joos
+Copyright (C) 2016 - 2018 Order of the Bee
 
 This file is part of Community Support Tools
 
@@ -19,7 +19,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
 
 Linked to Alfresco
-Copyright (C) 2005-2017 Alfresco Software Limited.
+Copyright (C) 2005-2018 Alfresco Software Limited.
  
   -->
   

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.html.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.html.ftl
@@ -1,6 +1,6 @@
 <#-- 
-Copyright (C) 2016, 2017 Axel Faust
-Copyright (C) 2016, 2017 Order of the Bee
+Copyright (C) 2016 - 2018 Axel Faust
+Copyright (C) 2016 - 2018 Order of the Bee
 
 This file is part of Community Support Tools
 
@@ -18,7 +18,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
 
 Linked to Alfresco
-Copyright (C) 2005-2017 Alfresco Software Limited.
+Copyright (C) 2005-2018 Alfresco Software Limited.
  
   -->
 

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.js
@@ -2,8 +2,8 @@
 <import resource="classpath:alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js">
 
 /**
- * Copyright (C) 2016, 2017 Axel Faust
- * Copyright (C) 2016, 2017 Order of the Bee
+ * Copyright (C) 2016 - 2018 Axel Faust
+ * Copyright (C) 2016 - 2018 Order of the Bee
  *
  * This file is part of Community Support Tools
  *
@@ -22,7 +22,7 @@
  */
 /*
  * Linked to Alfresco
- * Copyright (C) 2005-2017 Alfresco Software Limited.
+ * Copyright (C) 2005-2018 Alfresco Software Limited.
  */
 
 

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.json.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.json.ftl
@@ -1,7 +1,7 @@
 <#compress>
 <#-- 
-Copyright (C) 2016, 2017 Axel Faust
-Copyright (C) 2016, 2017 Order of the Bee
+Copyright (C) 2016 - 2018 Axel Faust
+Copyright (C) 2016 - 2018 Order of the Bee
 
 This file is part of Community Support Tools
 
@@ -19,7 +19,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
 
 Linked to Alfresco
-Copyright (C) 2005-2017 Alfresco Software Limited.
+Copyright (C) 2005-2018 Alfresco Software Limited.
  
   -->
 <#escape x as jsonUtils.encodeJSONString(x)>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2016, 2017 Axel Faust
- * Copyright (C) 2016, 2017 Order of the Bee
+ * Copyright (C) 2016 - 2018 Axel Faust
+ * Copyright (C) 2016 - 2018 Order of the Bee
  *
  * This file is part of Community Support Tools
  *
@@ -19,7 +19,7 @@
  */
 /*
  * Linked to Alfresco
- * Copyright (C) 2005-2017 Alfresco Software Limited.
+ * Copyright (C) 2005-2018 Alfresco Software Limited.
  */
 function mapCacheMetrics(metrics, cacheInfo)
 {
@@ -51,14 +51,15 @@ function mapCacheMetrics(metrics, cacheInfo)
 
 function buildCacheInfo(cacheName, cache, allowClearGlobal, propertyGetter)
 {
-    var maxItems, cacheInfo, invHandler, alfCacheStatsEnabled, alfCacheStats, stats;
+    var configCacheName, maxItems, cacheInfo, invHandler, alfCacheStatsEnabled, alfCacheStats, stats;
 
-    maxItems = propertyGetter('cache.' + cacheName + '.maxItems', '-1');
+    configCacheName = propertyGetter('cache.' + cacheName + '.configCacheName', cacheName);
+    maxItems = propertyGetter('cache.' + configCacheName + '.maxItems', '-1');
 
     cacheInfo = {
         name : cacheName,
-        definedType : propertyGetter('cache.' + cacheName + '.cluster.type', ''),
-        clearable : allowClearGlobal && propertyGetter('cache.' + cacheName + '.clearable', '').toLowerCase() === 'true',
+        definedType : propertyGetter('cache.' + configCacheName + '.cluster.type', ''),
+        clearable : allowClearGlobal && propertyGetter('cache.' + configCacheName + '.clearable', '').toLowerCase() === 'true',
         type : '',
         size : cache.keys.size(),
         maxSize : parseInt(maxItems, 10),
@@ -86,7 +87,7 @@ function buildCacheInfo(cacheName, cache, allowClearGlobal, propertyGetter)
         cacheInfo.type = String(cache.class.name);
     }
 
-    alfCacheStatsEnabled = propertyGetter('cache.' + cacheName + '.tx.statsEnabled', '').toLowerCase() === 'true';
+    alfCacheStatsEnabled = propertyGetter('cache.' + configCacheName + '.tx.statsEnabled', '').toLowerCase() === 'true';
 
     if (alfCacheStatsEnabled)
     {

--- a/repository/src/main/amp/web/ootbee-support-tools/js/caches.js
+++ b/repository/src/main/amp/web/ootbee-support-tools/js/caches.js
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2016, 2017 Axel Faust
- * Copyright (C) 2016, 2017 Order of the Bee
+ * Copyright (C) 2016 - 2018 Axel Faust
+ * Copyright (C) 2016 - 2018 Order of the Bee
  * 
  * This file is part of Community Support Tools
  * 
@@ -20,7 +20,7 @@
  */
 /*
  * Linked to Alfresco Copyright
- * (C) 2005-2017 Alfresco Software Limited.
+ * (C) 2005-2018 Alfresco Software Limited.
  */
 
 /* global Admin: false, $: false*/


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR adds logic to redirect config lookup from the effective cache bean name to the originally configured cache bean name for a set of specific caches known to be inconsistent between config time and runtime.

### RELATED INFORMATION

Fixes #123

This PR also includes updates to copyright notices for all JS / FTL files of the affected tool as well as the global admin template.