### PR TITLE
Script to send Travis build status to Discord

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ jdk:
 cache:
   directories:
   - $HOME/.m2
+after_success:
+  - ./send-to-discord.sh success $DISCORD_WEBHOOK_URL
+after_failure:
+  - ./send-to-discord.sh failure $DISCORD_WEBHOOK_URL

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
   directories:
   - $HOME/.m2
 after_success:
+  - chmod +x send-to-discord.sh
   - ./send-to-discord.sh success $DISCORD_WEBHOOK_URL
 after_failure:
+  - chmod +x send-to-discord.sh
   - ./send-to-discord.sh failure $DISCORD_WEBHOOK_URL

--- a/send-to-discord.sh
+++ b/send-to-discord.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# This is a simplified variant of https://github.com/k3rn31p4nic/travis-ci-discord-webhook/blob/master/send.sh
+# Adapted to send simple text message instead of embedded content
+# This allows message to be accessed by users that have compact mode enabled
+
+if [ -z "$2" ]; then
+    echo -e "WARNING!!\nYou need to pass the WEBHOOK_URL environment variable as the second argument to this script.\nFor details & guide, visit: https://github.com/k3rn31p4nic/travis-ci-discord-webhook" && exit
+fi
+
+echo -e "[Webhook]: Sending webhook to Discord...\\n";
+
+case $1 in
+  "success" )
+    STATUS_MESSAGE="Passed"
+    AVATAR="https://travis-ci.org/images/logos/TravisCI-Mascot-blue.png"
+    ;;
+
+  "failure" )
+    STATUS_MESSAGE="Failed"
+    AVATAR="https://travis-ci.org/images/logos/TravisCI-Mascot-red.png"
+    ;;
+
+  * )
+    STATUS_MESSAGE="Status Unknown"
+    AVATAR="https://travis-ci.org/images/logos/TravisCI-Mascot-1.png"
+    ;;
+esac
+
+AUTHOR_NAME="$(git log -1 "$TRAVIS_COMMIT" --pretty="%aN")"
+COMMITTER_NAME="$(git log -1 "$TRAVIS_COMMIT" --pretty="%cN")"
+COMMIT_SUBJECT="$(git log -1 "$TRAVIS_COMMIT" --pretty="%s")"
+
+if [ "$AUTHOR_NAME" == "$COMMITTER_NAME" ]; then
+    CREDITS="$AUTHOR_NAME authored & committed"
+else
+    CREDITS="$AUTHOR_NAME authored & $COMMITTER_NAME committed"
+fi
+
+TRAVIS_URL="https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID"
+
+if [[ $TRAVIS_PULL_REQUEST != false ]]; then
+    GITHUB_URL="https://github.com/$TRAVIS_REPO_SLUG/pull/$TRAVIS_PULL_REQUEST"
+
+    WEBHOOK_DATA='{
+      "username": "Travis CI",
+      "avatar_url": "'"$AVATAR"'",
+      "content" : "'"$STATUS_MESSAGE"'" Travis CI pull request build: '"$COMMIT_SUBJECT"' ('"$CREDITS"', see '"$GITHUB_URL"' / '"$TRAVIS_URL"')"
+    }'
+else
+    GITHUB_URL="https://github.com/$TRAVIS_REPO_SLUG/commit/$TRAVIS_COMMIT"
+
+    WEBHOOK_DATA='{
+      "username": "Travis CI",
+      "avatar_url": "'"$AVATAR"'",
+      "content" : "'"$STATUS_MESSAGE"'" Travis CI commit build: '"$COMMIT_SUBJECT"' ('"$CREDITS"', see '"$GITHUB_URL"' / '"$TRAVIS_URL"')"
+    }'
+fi
+
+(curl --fail --progress-bar -A "TravisCI-Webhook" -H Content-Type:application/json -d "$WEBHOOK_DATA" "$2" \
+&& echo -e "\\n[Webhook]: Successfully sent the webhook.") || echo -e "\\n[Webhook]: Unable to send webhook."

--- a/send-to-discord.sh
+++ b/send-to-discord.sh
@@ -29,8 +29,6 @@ esac
 
 AUTHOR_NAME="$(git log -1 "$TRAVIS_COMMIT" --pretty="%aN")"
 COMMITTER_NAME="$(git log -1 "$TRAVIS_COMMIT" --pretty="%cN")"
-COMMIT_SUBJECT="$(git log -1 "$TRAVIS_COMMIT" --pretty="%s")"
-
 if [ "$AUTHOR_NAME" == "$COMMITTER_NAME" ]; then
     CREDITS="$AUTHOR_NAME authored & committed"
 else
@@ -42,18 +40,20 @@ TRAVIS_URL="https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID"
 if [[ $TRAVIS_PULL_REQUEST != false ]]; then
     GITHUB_URL="https://github.com/$TRAVIS_REPO_SLUG/pull/$TRAVIS_PULL_REQUEST"
 
+    # GitHub commit subjects for PRs seem to be useless so we just rely on the pull request number, source repository and branch
     WEBHOOK_DATA='{
       "username": "Travis CI",
       "avatar_url": "'"$AVATAR"'",
-      "content" : "'"$STATUS_MESSAGE"'" Travis CI pull request build: '"$COMMIT_SUBJECT"' ('"$CREDITS"', see '"$GITHUB_URL"' / '"$TRAVIS_URL"')"
+      "content" : "'"$STATUS_MESSAGE"'" Travis CI build on pull request '"$TRAVIS_PULL_REQUEST"' from '"$TRAVIS_PULL_REQUEST_SLUG"', branch '"$TRAVIS_PULL_REQUEST_BRANCH"' ('"$CREDITS"', see '"$GITHUB_URL"' / '"$TRAVIS_URL"')"
     }'
 else
     GITHUB_URL="https://github.com/$TRAVIS_REPO_SLUG/commit/$TRAVIS_COMMIT"
+    COMMIT_SUBJECT="$(git log -1 "$TRAVIS_COMMIT" --pretty="%s")"
 
     WEBHOOK_DATA='{
       "username": "Travis CI",
       "avatar_url": "'"$AVATAR"'",
-      "content" : "'"$STATUS_MESSAGE"'" Travis CI commit build: '"$COMMIT_SUBJECT"' ('"$CREDITS"', see '"$GITHUB_URL"' / '"$TRAVIS_URL"')"
+      "content" : "'"$STATUS_MESSAGE"' Travis CI build on commit to '"$TRAVIS_BRANCH"': '"$COMMIT_SUBJECT"' ('"$CREDITS"', see '"$GITHUB_URL"' / '"$TRAVIS_URL"')"
     }'
 fi
 


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR adds a post-build script to send the build status to the OrderOfTheBee Discord server via webhook. The required DISCORD_WEBHOOK_URL environment variable has already been added to the Travis CI build settings and the webhook created on the Discord server for the support-tools channel.

### RELATED INFORMATION

The script is based on https://github.com/k3rn31p4nic/travis-ci-discord-webhook and has been adapted to only send regular text messages instead of embedded objects, which are only being displayed to users that have not enabled the compact display mode.
This PR will also inherently be the test to determine if the feature works as intended, so additional fix commits may be unavoidable.