### PR TITLE
ESLint config for Codacy

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,8 +4,9 @@
 **/webscripts/**/*.put.js
 **/webscripts/**/*.post.json.js
 **/webscripts/**/*.put.json.js
-**/moment-with-locales.min.js
-**/jquery-2.2.3.js
-**/jquery.dataTables.js
-**/dataTables.buttons.min.js
-**/dataTables.bootstrap4.min.js
+**/web/ootbee-support-tools/js/moment-with-locales.min.js
+**/web/ootbee-support-tools/js/smoothie.js
+**/web/ootbee-support-tools/js/jquery-2.2.3.js
+**/web/ootbee-support-tools/js/jquery.dataTables.js
+**/web/ootbee-support-tools/js/dataTables.buttons.min.js
+**/web/ootbee-support-tools/js/dataTables.bootstrap4.min.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,11 @@
+**/webscripts/**/*.get.js
+**/webscripts/**/*.delete.js
+**/webscripts/**/*.post.js
+**/webscripts/**/*.put.js
+**/webscripts/**/*.post.json.js
+**/webscripts/**/*.put.json.js
+**/moment-with-locales.min.js
+**/jquery-2.2.3.js
+**/jquery.dataTables.js
+**/dataTables.buttons.min.js
+**/dataTables.bootstrap4.min.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,91 @@
+{
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 5,
+        "sourceType": "script"
+    },
+    "env": {
+        "browser": true,
+        "nashorn": true,
+        "jquery": true
+    },
+    "globals": {
+        "guest": false,
+        "server": false,
+        "model": false,
+        "args": false,
+        "argsM": false,
+        "cache": false,
+        "headers": false,
+        "headersM": false,
+        "session": false,
+        "url": false,
+        "format": false,
+        "jsonUtils": false,
+        "logger": false,
+        "msg": false,
+        "json": false,
+        "status": false,
+        "config": false,
+        "companyhome": false,
+        "document": false,
+        "person": false,
+        "roothome": false,
+        "script": false,
+        "space": false,
+        "userhome": false,
+        "actions": false,
+        "activities": false,
+        "appUtils": false,
+        "bulkFSImport": false,
+        "classification": false,
+        "cmis": false,
+        "cmisServer": false,
+        "crossRepoCopy": false,
+        "imap": false,
+        "paging": false,
+        "people": false,
+        "presence": false,
+        "search": false,
+        "slingshotDocLib": false,
+        "utils": false,
+        "webprojects": false,
+        "workflow": false,
+        "siteService": false,
+        "Admin": false
+    },
+    "rules": {
+        "no-bitwise": "off",
+        "curly": "error",
+        "eqeqeq": "error",
+        "guard-for-in": "error",
+        "no-undef": "error",
+        "no-use-before-define": "error",
+        "no-caller": "error",
+        "new-cap": "error",
+        "no-new-object": "error",
+        "strict": "off",
+        "no-unused-vars": "error",
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "one-var": [
+            "error",
+            {
+                "var": "always",
+                "let": "never",
+                "const": "never"
+            }
+        ],
+        "vars-on-top": "error",
+        "semi": [
+            "error",
+            "always"
+        ],
+        "radix": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -151,6 +151,7 @@
                         <exclude>amp/config/alfresco/templates/webscripts/**/*.post.json.js</exclude>
                         <exclude>amp/config/alfresco/templates/webscripts/**/*.put.json.js</exclude>
                         <exclude>amp/web/ootbee-support-tools/js/moment-with-locales.min.js</exclude>
+                        <exclude>amp/web/ootbee-support-tools/js/smoothie.js</exclude>
                         <exclude>amp/web/ootbee-support-tools/js/jquery-2.2.3.js</exclude>
                         <exclude>amp/web/ootbee-support-tools/js/jquery.dataTables.js</exclude>
                         <exclude>amp/web/ootbee-support-tools/js/dataTables.buttons.min.js</exclude>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/.eslintrc.json
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/.eslintrc.json
@@ -1,0 +1,89 @@
+{
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 3,
+        "sourceType": "script"
+    },
+    "env": {
+        "nashorn": true
+    },
+    "globals": {
+        "guest": false,
+        "server": false,
+        "model": false,
+        "args": false,
+        "argsM": false,
+        "cache": false,
+        "headers": false,
+        "headersM": false,
+        "session": false,
+        "url": false,
+        "format": false,
+        "jsonUtils": false,
+        "logger": false,
+        "msg": false,
+        "json": false,
+        "status": false,
+        "config": false,
+        "companyhome": false,
+        "document": false,
+        "person": false,
+        "roothome": false,
+        "script": false,
+        "space": false,
+        "userhome": false,
+        "actions": false,
+        "activities": false,
+        "appUtils": false,
+        "bulkFSImport": false,
+        "classification": false,
+        "cmis": false,
+        "cmisServer": false,
+        "crossRepoCopy": false,
+        "imap": false,
+        "paging": false,
+        "people": false,
+        "presence": false,
+        "search": false,
+        "slingshotDocLib": false,
+        "utils": false,
+        "webprojects": false,
+        "workflow": false,
+        "siteService": false,
+        "Admin": false
+    },
+    "rules": {
+        "no-bitwise": "off",
+        "curly": "error",
+        "eqeqeq": "error",
+        "guard-for-in": "error",
+        "no-undef": "error",
+        "no-use-before-define": "error",
+        "no-caller": "error",
+        "new-cap": "off",
+        "no-new-object": "error",
+        "strict": "off",
+        "no-unused-vars": "error",
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "one-var": [
+            "error",
+            {
+                "var": "always",
+                "let": "never",
+                "const": "never"
+            }
+        ],
+        "vars-on-top": "error",
+        "semi": [
+            "error",
+            "always"
+        ],
+        "radix": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/repository/src/main/amp/web/ootbee-support-tools/.eslintrc.json
+++ b/repository/src/main/amp/web/ootbee-support-tools/.eslintrc.json
@@ -4,13 +4,19 @@
         "ecmaVersion": 5,
         "sourceType": "script"
     },
+    "env": {
+        "browser": true,
+        "jquery": true
+    },
+    "globals": {
+    },
     "rules": {
         "no-bitwise": "off",
         "curly": "error",
         "eqeqeq": "error",
         "guard-for-in": "error",
         "no-undef": "error",
-        "no-use-before-define": "error",
+        "no-use-before-define": "off",
         "no-caller": "error",
         "new-cap": "off",
         "no-new-object": "error",

--- a/share/src/main/amp/config/alfresco/site-webscripts/org/orderofthebee/support-tools/.eslintrc.json
+++ b/share/src/main/amp/config/alfresco/site-webscripts/org/orderofthebee/support-tools/.eslintrc.json
@@ -1,8 +1,36 @@
 {
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 5,
+        "ecmaVersion": 3,
         "sourceType": "script"
+    },
+    "env": {
+        "browser": true,
+        "nashorn": true
+    },
+    "globals": {
+        "guest": false,
+        "server": false,
+        "model": false,
+        "args": false,
+        "argsM": false,
+        "cache": false,
+        "headers": false,
+        "headersM": false,
+        "session": false,
+        "url": false,
+        "format": false,
+        "jsonUtils": false,
+        "logger": false,
+        "msg": false,
+        "json": false,
+        "status": false,
+        "config": false,
+        "page": false,
+        "remote": false,
+        "instance": false,
+        "sitedata": false,
+        "widgetUtils": false
     },
     "rules": {
         "no-bitwise": "off",

--- a/share/src/main/amp/web/ootbee-support-tools/.eslintrc.json
+++ b/share/src/main/amp/web/ootbee-support-tools/.eslintrc.json
@@ -4,6 +4,11 @@
         "ecmaVersion": 5,
         "sourceType": "script"
     },
+    "env": {
+        "browser": true
+    },
+    "globals": {
+    },
     "rules": {
         "no-bitwise": "off",
         "curly": "error",


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR provides configuration files to configure the ESLint validator used by Codacy to align the issues reported by Codacy as best as possible with our Maven-run JSHint.

### RELATED INFORMATION

ESLint is being used in Codacy as it includes quite a lot more validation rules / options than JSHint (maybe in the future we might want to change our Maven-run validation to ESLint too). According to Codacy, only the root level of the project is scanned for an ESLint configuration file, and there is no mention of supporting sub-directory level overrides (as we use for JSHint), even though ESLint itself apparently supports this. This PR provides both global-level configuration files and low-level overrides since tests in my fork have concluded that the ESLint way of looking at low-level overrides also applies to running ESLint on Codacy.