### PR TITLE
Command console tool with initial permission plugin

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -142,22 +142,6 @@
             <plugin>
                 <groupId>de.acosix.maven</groupId>
                 <artifactId>jshint-maven-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>amp/config/alfresco/templates/webscripts/**/*.get.js</exclude>
-                        <exclude>amp/config/alfresco/templates/webscripts/**/*.delete.js</exclude>
-                        <exclude>amp/config/alfresco/templates/webscripts/**/*.post.js</exclude>
-                        <exclude>amp/config/alfresco/templates/webscripts/**/*.put.js</exclude>
-                        <exclude>amp/config/alfresco/templates/webscripts/**/*.post.json.js</exclude>
-                        <exclude>amp/config/alfresco/templates/webscripts/**/*.put.json.js</exclude>
-                        <exclude>amp/web/ootbee-support-tools/js/moment-with-locales.min.js</exclude>
-                        <exclude>amp/web/ootbee-support-tools/js/smoothie.js</exclude>
-                        <exclude>amp/web/ootbee-support-tools/js/jquery-2.2.3.js</exclude>
-                        <exclude>amp/web/ootbee-support-tools/js/jquery.dataTables.js</exclude>
-                        <exclude>amp/web/ootbee-support-tools/js/dataTables.buttons.min.js</exclude>
-                        <exclude>amp/web/ootbee-support-tools/js/dataTables.bootstrap4.min.js</exclude>
-                    </excludes>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/repository/src/main/amp/config/alfresco/messages/ootbee-support-tools.properties
+++ b/repository/src/main/amp/config/alfresco/messages/ootbee-support-tools.properties
@@ -32,3 +32,11 @@ admin-console.tool.caches.description=Overview of caches
 
 admin-console.tool.solr-tracking.label=SOLR tracking status
 admin-console.tool.solr-tracking.description=Get information about SOLR tracking status
+
+admin-console.tool.command-console.label=Command Console
+admin-console.tool.command-console.description=Perform granular administration tasks
+
+ootbee-support-tools.command-console.global.description=The global plugin provides the default commands required to work with the switch between plugins and inspect the available global commands.
+ootbee-support-tools.command-console.global.help.description=Displays the list of commands and their supported arguments within the current plugin
+ootbee-support-tools.command-console.global.listPlugins.description=Displays the list of available plugins
+ootbee-support-tools.command-console.global.activatePlugin.description=Activates the specified plugin for all future commands, and immediately displays its list of commands and their supported arguments

--- a/repository/src/main/amp/config/alfresco/messages/ootbee-support-tools.properties
+++ b/repository/src/main/amp/config/alfresco/messages/ootbee-support-tools.properties
@@ -40,3 +40,9 @@ ootbee-support-tools.command-console.global.description=The global plugin provid
 ootbee-support-tools.command-console.global.help.description=Displays the list of commands and their supported arguments within the current plugin
 ootbee-support-tools.command-console.global.listPlugins.description=Displays the list of available plugins
 ootbee-support-tools.command-console.global.activatePlugin.description=Activates the specified plugin for all future commands, and immediately displays its list of commands and their supported arguments
+
+ootbee-support-tools.command-console.permissions.description=The permissions plugin provides commands for checking / working with permissions on nodes.
+ootbee-support-tools.command-console.permissions.help.description=Displays the list of commands and their supported arguments within the current plugin
+ootbee-support-tools.command-console.permissions.effectivePermission.description=Checks if a user has a specific permission on a specific node
+ootbee-support-tools.command-console.permissions.effectivePermissions.description=Checks all settable permissions on a specific node for a specific user 
+ootbee-support-tools.command-console.permissions.effectivePermissions.flexibleParameterPairs=The order of parameter pairs (key <value>) is flexible

--- a/repository/src/main/amp/config/alfresco/messages/ootbee-support-tools_de.properties
+++ b/repository/src/main/amp/config/alfresco/messages/ootbee-support-tools_de.properties
@@ -40,3 +40,9 @@ ootbee-support-tools.command-console.global.description=Das Plugin 'global' stel
 ootbee-support-tools.command-console.global.help.description=Zeigt die Liste der Befehle des aktuellen Plugins und deren unterst\u00fctzte Parameter an
 ootbee-support-tools.command-console.global.listPlugins.description=Zeigt die Liste der bereitgestellten Plugins an
 ootbee-support-tools.command-console.global.activatePlugin.description=Aktiviert ein bestimmtes Plugin als Kontext f\u00fcr weitere Befehle, und zeigt die Liste der Befehle deren unterst\u00fctzte Parameter an
+
+ootbee-support-tools.command-console.permissions.description=Das Plugin 'permissions' enth\u00e4lt Befehle zum Pr\u00fcfen / Arbeiten mit Berechtigungen auf Knoten.
+ootbee-support-tools.command-console.permissions.help.description=Zeigt die Liste der Befehle des aktuellen Plugins und deren unterst\u00fctzte Parameter an
+ootbee-support-tools.command-console.permissions.effectivePermission.description=Pr\u00fcft ob ein Nutzer eine bestimmte Berechtigung auf einem bestimmten Knoten besitzt bzw. diese ihm zugewiesen wurde
+ootbee-support-tools.command-console.permissions.effectivePermissions.description=Pr\u00fcft f\u00fcr alle vergebbaren Berechtigungen ob ein Nutzer diese auf einem bestimmten Knoten besitzt bzw. diese ihm zugewiesen wurde
+ootbee-support-tools.command-console.permissions.effectivePermissions.flexibleParameterPairs=Die Reihenfolge der Parameterpaare (Schl\u00fcssel <Wert>) ist flexibel

--- a/repository/src/main/amp/config/alfresco/messages/ootbee-support-tools_de.properties
+++ b/repository/src/main/amp/config/alfresco/messages/ootbee-support-tools_de.properties
@@ -32,3 +32,11 @@ admin-console.tool.caches.description=\u00dcbersicht der Caches
 
 admin-console.tool.solr-tracking.label=SOLR Indizierungsstatus
 admin-console.tool.solr-tracking.description=Status der SOLR Indizierung
+
+admin-console.tool.command-console.label=Befehlskonsole
+admin-console.tool.command-console.description=Ausf\u00fchren von granularen Administrationsaufgaben
+
+ootbee-support-tools.command-console.global.description=Das Plugin 'global' stellt die vordefinierten Befehle zur Verf\u00fcgung, die f\u00fcr das Wechseln zwischen Plugins und inspizieren der globalen Befehle notwendig sind
+ootbee-support-tools.command-console.global.help.description=Zeigt die Liste der Befehle des aktuellen Plugins und deren unterst\u00fctzte Parameter an
+ootbee-support-tools.command-console.global.listPlugins.description=Zeigt die Liste der bereitgestellten Plugins an
+ootbee-support-tools.command-console.global.activatePlugin.description=Aktiviert ein bestimmtes Plugin als Kontext f\u00fcr weitere Befehle, und zeigt die Liste der Befehle deren unterst\u00fctzte Parameter an

--- a/repository/src/main/amp/config/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
+++ b/repository/src/main/amp/config/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
@@ -61,3 +61,6 @@ cache.siteNodeRefSharedCache.clearable=true
 cache.solrFacetNodeRefSharedCache.clearable=true
 
 # other caches we currently assume are not safe to be cleared at runtime
+
+# comma-separated list of available plugins
+ootbee-support-tools.command-console.plugins=global

--- a/repository/src/main/amp/config/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
+++ b/repository/src/main/amp/config/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
@@ -63,4 +63,4 @@ cache.solrFacetNodeRefSharedCache.clearable=true
 # other caches we currently assume are not safe to be cleared at runtime
 
 # comma-separated list of available plugins
-ootbee-support-tools.command-console.plugins=global
+ootbee-support-tools.command-console.plugins=global,permissions

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/.jshintignore
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/.jshintignore
@@ -1,0 +1,6 @@
+*.get.js
+*.delete.js
+*.post.js
+*.put.js
+*.post.json.js
+*.put.json.js

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/global-commands.post.desc.xml
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/global-commands.post.desc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<webscript>
+    <shortname>Command Console - Global Commands</shortname>
+    <description>Executes supported commands of the global command console plugin</description>
+    <url>/ootbee/admin/command-console/global/help</url>
+    <url>/ootbee/admin/command-console/global/listPlugins</url>
+    <family>OOTBee Support Tools</family>
+    <format default="json">any</format>
+    <negotiate accept="application/json">json</negotiate>
+    <authentication>admin</authentication>
+    <lifecycle>internal</lifecycle>
+    <transaction>none</transaction>
+</webscript>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/global-commands.post.json.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/global-commands.post.json.ftl
@@ -1,0 +1,49 @@
+<#compress>
+<#-- 
+Copyright (C) 2018 Axel Faust
+Copyright (C) 2018 Order of the Bee
+
+This file is part of Community Support Tools
+
+Community Support Tools is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Community Support Tools is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
+
+Linked to Alfresco
+Copyright (C) 2005-2017 Alfresco Software Limited.
+ 
+  -->
+<#escape x as jsonUtils.encodeJSONString(x)>
+{
+    "preformattedOutputLines": [
+        <#switch command>
+            <#case "help">
+                "help",
+                "\t${msg("ootbee-support-tools.command-console.global.help.description")}",
+                "",
+                "listPlugins",
+                "\t${msg("ootbee-support-tools.command-console.global.listPlugins.description")}",
+                "",
+                "activatePlugin <plugin>",
+                "\t${msg("ootbee-support-tools.command-console.global.activatePlugin.description")}"
+                <#break>
+            <#case "listPlugins">
+                <#list availablePlugins as plugin>
+                "${plugin}",
+                "\t${msg("ootbee-support-tools.command-console." + plugin + ".description")}"<#if plugin_has_next>, "",</#if>
+                </#list>
+                <#break>
+        </#switch>
+    ]
+}
+</#escape>
+</#compress>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/global-commands.post.json.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/global-commands.post.json.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2018 Axel Faust
+ * Copyright (C) 2018 Order of the Bee
+ *
+ * This file is part of Community Support Tools
+ *
+ * Community Support Tools is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Community Support Tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Linked to Alfresco
+ * Copyright (C) 2005-2018 Alfresco Software Limited.
+ */
+
+function buildPropertyGetter(ctxt)
+{
+    var globalProperties, placeholderHelper, propertyGetter;
+
+    globalProperties = ctxt.getBean('global-properties', Packages.java.util.Properties);
+    placeholderHelper = new Packages.org.springframework.util.PropertyPlaceholderHelper('${', '}', ':', true);
+
+    propertyGetter = function(propertyName, defaultValue)
+    {
+        var propertyValue;
+
+        propertyValue = globalProperties[propertyName];
+        if (propertyValue)
+        {
+            propertyValue = placeholderHelper.replacePlaceholders(propertyValue, globalProperties);
+        }
+
+        // native JS strings are always preferrable
+        if (propertyValue !== undefined && propertyValue !== null)
+        {
+            propertyValue = String(propertyValue);
+        }
+        else if (defaultValue !== undefined)
+        {
+            propertyValue = defaultValue;
+        }
+        
+        return propertyValue;
+    };
+
+    return propertyGetter;
+}
+
+function main()
+{
+    var service, ctxt, propertyGetter, availablePlugins;
+
+    service = String(url.service);
+    model.command = service.substring(service.lastIndexOf('/') + 1);
+    if (model.command === 'listPlugins')
+    {
+        ctxt = Packages.org.springframework.web.context.ContextLoader.getCurrentWebApplicationContext();
+        propertyGetter = buildPropertyGetter(ctxt);
+        availablePlugins = propertyGetter('ootbee-support-tools.command-console.plugins', 'global');
+        model.availablePlugins = availablePlugins.trim().split(/\s*,\s*/g);
+    }
+}
+
+main();

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/permission-commands.post.desc.xml
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/permission-commands.post.desc.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<webscript>
+    <shortname>Command Console - Permission Commands</shortname>
+    <description>Executes supported commands of the permissions command console plugin</description>
+    <url>/ootbee/admin/command-console/permissions/help</url>
+    <url>/ootbee/admin/command-console/permissions/effectivePermission</url>
+    <url>/ootbee/admin/command-console/permissions/effectivePermissions</url>
+    <family>OOTBee Support Tools</family>
+    <format default="json">any</format>
+    <negotiate accept="application/json">json</negotiate>
+    <authentication>admin</authentication>
+    <lifecycle>internal</lifecycle>
+    <transaction bufferSize="8192" allow="readonly">required</transaction>
+</webscript>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/permission-commands.post.json.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/permission-commands.post.json.ftl
@@ -1,0 +1,51 @@
+<#compress>
+<#-- 
+Copyright (C) 2018 Axel Faust
+Copyright (C) 2018 Order of the Bee
+
+This file is part of Community Support Tools
+
+Community Support Tools is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Community Support Tools is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
+
+Linked to Alfresco
+Copyright (C) 2005-2017 Alfresco Software Limited.
+ 
+  -->
+<#escape x as jsonUtils.encodeJSONString(x)>
+{
+    "preformattedOutputLines": [
+        <#switch command>
+            <#case "help">
+                "help",
+                "\t${msg("ootbee-support-tools.command-console.permissions.help.description")}",
+                "",
+                "effectivePermission user <userName> permission <permission> node <nodeRef>",
+                "\t${msg("ootbee-support-tools.command-console.permissions.effectivePermission.description")}",
+                "\t${msg("ootbee-support-tools.command-console.permissions.effectivePermissions.flexibleParameterPairs")}",
+                "",
+                "effectivePermissions user <userName> node <nodeRef>",
+                "\t${msg("ootbee-support-tools.command-console.permissions.effectivePermissions.description")}",
+                "\t${msg("ootbee-support-tools.command-console.permissions.effectivePermissions.flexibleParameterPairs")}"
+                <#break>
+            <#case "effectivePermission">
+            <#case "effectivePermissions">
+                <#list checkedPermissions as checkedPermission>
+                "${msg("permissionCheck.result", checkedPermission.user, checkedPermission.permission, checkedPermission.node.nodeRef, checkedPermission.node.name, checkedPermission.allowed?string(msg("permissionCheck.allowed"), msg("permissionCheck.denied")))}"<#if checkedPermission_has_next>,</#if>
+                </#list>
+                <#break>
+        </#switch>
+    ]
+}
+</#escape>
+</#compress>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/permission-commands.post.json.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/permission-commands.post.json.js
@@ -1,0 +1,171 @@
+/**
+ * Copyright (C) 2018 Axel Faust
+ * Copyright (C) 2018 Order of the Bee
+ * 
+ * This file is part of Community Support Tools
+ * 
+ * Community Support Tools is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * Community Support Tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Community Support Tools. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Linked to Alfresco Copyright
+ * (C) 2005-2018 Alfresco Software Limited.
+ */
+
+/* global json: false */
+
+function getPermissionService()
+{
+    var ctxt, permissionService;
+    ctxt = Packages.org.springframework.web.context.ContextLoader.getCurrentWebApplicationContext();
+    permissionService = ctxt.getBean('PermissionService', Packages.org.alfresco.service.cmr.security.PermissionService);
+    return permissionService;
+}
+
+function getAllSettablePermissions(node)
+{
+    var permissions, permissionsArr, permissionsIter;
+
+    permissions = getPermissionService().getSettablePermissions(node.nodeRef);
+    permissionsArr = [];
+    permissionsIter = permissions.iterator();
+    while (permissionsIter.hasNext())
+    {
+        permissionsArr.push(String(permissionsIter.next()));
+    }
+    return permissionsArr;
+}
+
+function runAsUser(fn, user)
+{
+    var result;
+    Packages.org.alfresco.repo.security.authentication.AuthenticationUtil.pushAuthentication();
+    Packages.org.alfresco.repo.security.authentication.AuthenticationUtil.setRunAsUser(user);
+    try
+    {
+        result = fn();
+        // restore
+        Packages.org.alfresco.repo.security.authentication.AuthenticationUtil.popAuthentication();
+    }
+    catch (e)
+    {
+
+        // restore
+        Packages.org.alfresco.repo.security.authentication.AuthenticationUtil.popAuthentication();
+        throw e;
+    }
+    return result;
+}
+
+function executeEffectivePermission(args, settable)
+{
+    var userArg, nodeArg, permissionArg, argIdx, node;
+
+    for (argIdx = 0; argIdx < args.length; argIdx++)
+    {
+        switch (args[argIdx])
+        {
+            case 'user':
+                userArg = (args.length > argIdx + 1) ? args[++argIdx] : null;
+                break;
+            case 'permission':
+                permissionArg = (args.length > argIdx + 1) ? args[++argIdx] : null;
+                break;
+            case 'node':
+                nodeArg = (args.length > argIdx + 1) ? args[++argIdx] : null;
+                break;
+        }
+    }
+
+    if (userArg && nodeArg && (settable === true || permissionArg))
+    {
+        node = search.findNode(nodeArg);
+        if (node !== null)
+        {
+            runAsUser(
+                    function()
+                    {
+                        var permissionService = getPermissionService();
+                        if (permissionArg && settable !== true)
+                        {
+                            model.checkedPermissions = [ {
+                                user : userArg,
+                                permission : permissionArg,
+                                node : node,
+                                allowed : permissionService.hasPermission(node.nodeRef, permissionArg) === Packages.org.alfresco.service.cmr.security.AccessStatus.ALLOWED
+                            } ];
+                        }
+                        else
+                        {
+                            model.checkedPermissions = [];
+                            getAllSettablePermissions(node)
+                                    .forEach(
+                                            function(permission)
+                                            {
+                                                model.checkedPermissions
+                                                        .push({
+                                                            user : userArg,
+                                                            permission : permission,
+                                                            node : node,
+                                                            allowed : permissionService.hasPermission(node.nodeRef, permission) === Packages.org.alfresco.service.cmr.security.AccessStatus.ALLOWED
+                                                        });
+                                            });
+                        }
+                    }, userArg);
+        }
+        else
+        {
+            status.setCode(status.STATUS_BAD_REQUEST, 'Node ' + nodeArg + ' does not exist');
+        }
+    }
+    else
+    {
+        status.setCode(status.STATUS_BAD_REQUEST, 'Missing arguments - command requires "user" and "node"');
+    }
+}
+
+function main()
+{
+    var service, reqBody, reqArgs, argIdx;
+
+    service = String(url.service);
+    model.command = service.substring(service.lastIndexOf('/') + 1);
+
+    // web script json is (unwieldly) org.json.JSONObject
+    reqBody = JSON.parse(json.toString());
+    reqArgs = [];
+    if (reqBody.arguments && Array.isArray(reqBody.arguments))
+    {
+        for (argIdx = 0; argIdx < reqBody.arguments.length; argIdx++)
+        {
+            reqArgs[argIdx] = reqBody.arguments[argIdx];
+        }
+    }
+
+    switch (model.command)
+    {
+        case 'effectivePermission':
+            executeEffectivePermission(reqArgs, false);
+            break;
+        case 'effectivePermissions':
+            executeEffectivePermission(reqArgs, true);
+            break;
+        case 'help': // no-op
+            break;
+        default:
+            status.setCode(status.STATUS_NOT_FOUND, 'Command not found');
+    }
+}
+
+main();

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/permission-commands.post.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/permission-commands.post.properties
@@ -1,0 +1,3 @@
+permissionCheck.result=User {0} is {4} permission {1} on {2} (name: {3})
+permissionCheck.allowed=granted
+permissionCheck.denied=denied

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/permission-commands.post_de.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/permission-commands.post_de.properties
@@ -1,0 +1,3 @@
+permissionCheck.result=Dem Nutzer {0} wurde die Berechtigung {1} auf {2} (Name: {3}) {4} 
+permissionCheck.allowed=gestattet
+permissionCheck.denied=verwehrt

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console.get.desc.xml
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console.get.desc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<webscript>
+    <shortname>Command Console</shortname>
+    <description>Interact with pluggable command interpreters to perform specific admin actions</description>
+    <url>/ootbee/admin/command-console</url>
+    <family>AdminConsole</family>
+    <family>OOTBee Support Tools</family>
+    <format default="html">any</format>
+    <negotiate accept="text/html">html</negotiate>
+    <authentication>admin</authentication>
+    <lifecycle>internal</lifecycle>
+    <transaction>none</transaction>
+</webscript>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console.get.html.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console.get.html.ftl
@@ -1,0 +1,63 @@
+<#-- 
+Copyright (C) 2018 Axel Faust
+Copyright (C) 2018 Order of the Bee
+
+This file is part of Community Support Tools
+
+Community Support Tools is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Community Support Tools is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
+
+Linked to Alfresco
+Copyright (C) 2005-2018 Alfresco Software Limited.
+ 
+  -->
+
+<#include "../admin-template.ftl" />
+
+<@page title=msg("command-console.title") controller="/ootbee/admin" readonly=true
+    customJSFiles=["ootbee-support-tools/js/command-console.js"]
+    customCSSFiles=["ootbee-support-tools/css/command-console.css"]>
+<#-- close the dummy form -->
+</form>
+    
+<script type="text/javascript">//<![CDATA[
+    AdminCC.setServiceContext('${url.serviceContext}');
+    
+    AdminCC.addMessages({
+        'command-console.error.authentication': '${msg("command-console.error.authentication")?js_string}',
+        'command-console.error.unknownCommand': '${msg("command-console.error.unknownCommand")?js_string}',
+        'command-console.error.unknownPlugin': '${msg("command-console.error.unknownPlugin")?js_string}',
+        'command-console.error.generic': '${msg("command-console.error.generic")?js_string}'
+    });
+//]]></script>
+
+    <div class="column-full">
+        <p class="intro">${msg("command-console.intro")?html}</p>
+        
+        <form onsubmit="return AdminCC.submitConsoleCommand(event);" accept-charset="utf-8">
+            <input id="command-console-command" type="text" name="command" placeholder="${msg("command-console.command")?html}"></input>
+            <input type="submit" value="${msg("command-console.execute")}" />
+        </form>
+        <div id="command-console-info">
+            <div>${msg("command-console.help")?html}</div>
+            <div>${msg("command-console.activePlugin")?html}:<span id="command-console-activePlugin">global</span></div>
+        </div>
+    </div>
+    
+    <div class="column-full">
+      <@section label=msg("command-console.result") />
+      <div>${msg("command-console.previousCommand")?html}:<span id="command-console-previousCommand"></span></div>
+      <div id="command-console-lastError" class="hidden"></div>
+      <div id="command-console-result"></div>
+   </div>
+</@page>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console.get.js
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console.get.js
@@ -1,0 +1,29 @@
+<import resource="classpath:alfresco/templates/webscripts/org/alfresco/repository/admin/admin-common.lib.js">
+<import resource="classpath:alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js">
+
+/**
+ * Copyright (C) 2018 Axel Faust
+ * Copyright (C) 2018 Order of the Bee
+ *
+ * This file is part of Community Support Tools
+ *
+ * Community Support Tools is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Community Support Tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Community Support Tools. If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Linked to Alfresco
+ * Copyright (C) 2005-2018 Alfresco Software Limited.
+ */
+
+model.tools = Admin.getConsoleTools('command-console');
+model.metadata = Admin.getServerMetaData();

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console.get.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console.get.properties
@@ -1,0 +1,14 @@
+command-console.title=Command Console
+command-console.intro=This tool allows to execute commands (provided by a list of command plugins) to perform individual administrative tasks which do not fit into full-fledged pages of their own.
+
+command-console.command=Enter command
+command-console.execute=Execute
+command-console.help=The command "help" will list available commands in the currently active plugin
+command-console.activePlugin=Active plugin
+command-console.result=Execution result
+command-console.previousCommand=Previous command
+
+command-console.error.authentication=Authentication timed out / required
+command-console.error.unknownCommand=Unknown command "{0}" in plugin "{1}"
+command-console.error.unknownPlugin=Unknown plugin "{0}"
+command-console.error.generic=An error occurred when running the last command

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console_de.get.properties
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console_de.get.properties
@@ -1,0 +1,14 @@
+command-console.title=Befehlskonsole
+command-console.intro=Diese Werkzeug erlaubt das Ausf\u00fchren von Befehlen (bereitgestellt durch Plugins) um einzelne Administrationsaufgaben auszuf\u00fchren, die zu granular f\u00fcr ein eigenes Werkzeug / eine eigene Seite sind.
+
+command-console.command=Geben Sie einen Befehl ein
+command-console.execute=Ausf\u00fchren
+command-console.help=Der Befehl "help" zeigt die verf\u00fcgbaren Befehle des aktuellen Plugins an
+command-console.activePlugin=Aktives Plugin
+command-console.result=Ergebnis der Befehlsausf\u00fchrung
+command-console.previousCommand=Vorheriger Befehl
+
+command-console.error.authentication=Die Anmeldung ist abgelaufen bzw. eine erneute Anmeldung erforderlich
+command-console.error.unknownCommand=Der Befehl "{0}" ist unbekannt im Plugin "{1}"
+command-console.error.unknownPlugin=Das Plugin "{0}" ist unbekannt
+command-console.error.generic=Ein Fehler ist beim Ausf\u00fchren des vorherigen Befehls aufgetreten

--- a/repository/src/main/amp/web/ootbee-support-tools/css/command-console.css
+++ b/repository/src/main/amp/web/ootbee-support-tools/css/command-console.css
@@ -1,0 +1,22 @@
+#command-console-command {
+    width: calc(100% - 15em);
+    margin-right: 1em;
+}
+
+#command-console-info,
+#command-console-result {
+    margin-top: 2ex;
+}
+
+#command-console-activePlugin,
+#command-console-previousCommand {
+    margin-left: 1em;
+}
+
+#command-console-lastError {
+    border: 2px solid red;
+    border-radius: 5px;
+    padding: 2.5px;
+    color: white;
+    background-color: red;
+}

--- a/repository/src/main/amp/web/ootbee-support-tools/js/.jshintignore
+++ b/repository/src/main/amp/web/ootbee-support-tools/js/.jshintignore
@@ -1,1 +1,6 @@
 smoothie.js
+moment-with-locales.min.js
+jquery-2.2.3.js
+jquery.dataTables.js
+dataTables.buttons.min.js
+dataTables.bootstrap4.min.js

--- a/repository/src/main/amp/web/ootbee-support-tools/js/command-console.js
+++ b/repository/src/main/amp/web/ootbee-support-tools/js/command-console.js
@@ -1,0 +1,228 @@
+/**
+ * Copyright (C) 2018 Axel Faust
+ * Copyright (C) 2018 Order of the Bee
+ * 
+ * This file is part of Community Support Tools
+ * 
+ * Community Support Tools is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * Community Support Tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Community Support Tools. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Linked to Alfresco Copyright
+ * (C) 2005-2018 Alfresco Software Limited.
+ */
+
+/* global Admin: false, el: false, alert: false */
+
+var AdminCC = AdminCC || {};
+
+(function()
+{
+    var serviceContext, messages = {}, activeCommandConsolePlugin = 'global';
+
+    AdminCC.setServiceContext = function setServiceContext(context)
+    {
+        serviceContext = context;
+    };
+
+    AdminCC.addMessages = function addMessage(oMessages)
+    {
+        var key;
+        if (oMessages !== undefined && oMessages !== null)
+        {
+            for (key in oMessages)
+            {
+                if (oMessages.hasOwnProperty(key))
+                {
+                    messages[key] = oMessages[key];
+                }
+            }
+        }
+    };
+
+    AdminCC.submitConsoleCommand = function submitConsoleCommand()
+    {
+        var commandInput, commandFragments, plugin, command, commandArgs, specialCommandSelected;
+
+        commandInput = el('command-console-command').value;
+
+        // unless a specific command is provided, help is the default (i.e. if missing input)
+        command = 'help';
+        if (commandInput)
+        {
+            try
+            {
+                commandFragments = AdminCC.parseCommandInput(commandInput);
+            }
+            catch (e)
+            {
+                alert('Failed to parse command: ' + e);
+                commandFragments = [];
+            }
+
+            if (commandFragments.length > 0 && commandFragments[0])
+            {
+                specialCommandSelected = false;
+
+                // check for special commands
+                switch (commandFragments[0].toLowerCase())
+                {
+                    case 'activateplugin':
+                        if (commandFragments.length > 1 && commandFragments[1])
+                        {
+                            activeCommandConsolePlugin = commandFragments[1];
+                            el('command-console-activePlugin').innerHTML = Admin.html(activeCommandConsolePlugin);
+                        }
+                        // show help - either for activated plugin or old (because argument was missing)
+                        command = 'help';
+                        specialCommandSelected = true;
+                        break;
+                    case 'listplugins':
+                        plugin = 'global';
+                        command = 'listPlugins';
+                        specialCommandSelected = true;
+                        break;
+                }
+
+                if (specialCommandSelected !== true)
+                {
+                    command = commandFragments[0];
+                    commandArgs = commandFragments.slice(1);
+                }
+            }
+        }
+
+        AdminCC.runCommand(plugin, command, commandArgs);
+
+        el('command-console-command').value = null;
+        el('command-console-lastError').innerHTML = '';
+        Admin.addClass(el('command-console-lastError'), 'hidden');
+        if (commandFragments)
+        {
+            el('command-console-previousCommand').innerHTML = Admin.html(commandFragments.join(' '));
+        }
+        else
+        {
+            el('command-console-previousCommand').innerHTML = Admin.html(command + ' ' + commandArgs.join(' '));
+        }
+
+        return false;
+    };
+
+    AdminCC.runCommand = function runCommand(plugin, command, commandArgs)
+    {
+        // default to currently active plugin if not specified
+        plugin = plugin || activeCommandConsolePlugin;
+        commandArgs = commandArgs || [];
+
+        Admin.request({
+            url : serviceContext + '/ootbee/admin/command-console/' + encodeURIComponent(plugin) + '/' + encodeURIComponent(command),
+            method : 'POST',
+            data : {
+                arguments : commandArgs
+            },
+            fnSuccess : function submitConsoleCommand__success(response)
+            {
+                var output, idx;
+
+                output = '';
+                // TODO How to support more flexibility (HTML provided by command plugin) without injection issues?
+                if (response.responseJSON.outputLines && Array.isArray(response.responseJSON.outputLines))
+                {
+                    for (idx = 0; idx < response.responseJSON.outputLines.length; idx++)
+                    {
+                        output += Admin.html(response.responseJSON.outputLines[idx]);
+                        output += '<br />';
+                    }
+                }
+                else if (response.responseJSON.preformattedOutputLines && Array.isArray(response.responseJSON.preformattedOutputLines))
+                {
+                    for (idx = 0; idx < response.responseJSON.preformattedOutputLines.length; idx++)
+                    {
+                        output += Admin.html(response.responseJSON.preformattedOutputLines[idx]);
+                        output += '\n';
+                    }
+                    output = '<pre>' + output + '</pre>';
+                }
+                else if (response.responseJSON.multilineOutput)
+                {
+                    output += Admin.html(response.responseJSON.multilineOutput);
+                }
+                else if (response.responseJSON.preformattedMultilineOutput)
+                {
+                    output += '<pre>' + Admin.html(response.responseJSON.preformattedMultilineOutput) + '</pre>';
+                }
+
+                el('command-console-result').innerHTML = output;
+            },
+            fnFailure : function submitConsoleCommand__failure(response)
+            {
+                var output;
+                if (response.responseStatus === 404)
+                {
+                    if (command !== 'help')
+                    {
+                        el('command-console-lastError').innerHTML = Admin.html(messages['command-console.error.unknownCommand'].replace(
+                                /\{0\}/, command).replace(/\{1\}/, plugin));
+                        AdminCC.runCommand(plugin, 'help', []);
+                    }
+                    else if (plugin !== 'global')
+                    {
+                        el('command-console-lastError').innerHTML = Admin.html(messages['command-console.error.unknownPlugin'].replace(
+                                /\{0\}/, plugin));
+                        activeCommandConsolePlugin = 'global';
+                        el('command-console-activePlugin').innerHTML = Admin.html(activeCommandConsolePlugin);
+                        AdminCC.runCommand('global', 'listPlugins', []);
+                    }
+                }
+                else if (response.responseStatus === 401)
+                {
+                    el('command-console-lastError').innerHTML = Admin.html(messages['command-console.error.authentication']);
+                }
+                else
+                {
+                    el('command-console-lastError').innerHTML = Admin.html(messages['command-console.error.generic']);
+                    // TODO Deal with JSON error response
+                    output = response.responseText;
+                }
+
+                Admin.removeClass(el('command-console-lastError'), 'hidden');
+                if (output)
+                {
+                    el('command-console-result').innerHTML = Admin.html(output);
+                }
+                else
+                {
+                    el('command-console-result').innerHTML = '';
+                }
+            }
+        });
+    };
+
+    AdminCC.parseCommandInput = function parseCommandInput(commandInput)
+    {
+        var pattern, matchResult, extractedFragments = [];
+
+        if (commandInput)
+        {
+            pattern = /("([^"\\](\\.)?)+"|[^\s]+)/g;
+            while ((matchResult = pattern.exec(commandInput)) !== null)
+            {
+                extractedFragments.push(matchResult[0]);
+            }
+        }
+
+        return extractedFragments;
+    };
+}());

--- a/repository/src/main/amp/web/ootbee-support-tools/js/command-console.js
+++ b/repository/src/main/amp/web/ootbee-support-tools/js/command-console.js
@@ -168,7 +168,7 @@ var AdminCC = AdminCC || {};
             },
             fnFailure : function submitConsoleCommand__failure(response)
             {
-                var output;
+                var output, jsonResponse;
                 if (response.responseStatus === 404)
                 {
                     if (command !== 'help')
@@ -193,8 +193,19 @@ var AdminCC = AdminCC || {};
                 else
                 {
                     el('command-console-lastError').innerHTML = Admin.html(messages['command-console.error.generic']);
-                    // TODO Deal with JSON error response
                     output = response.responseText;
+                    try
+                    {
+                        jsonResponse = JSON.parse(response.responseText);
+                        if (jsonResponse.message)
+                        {
+                            output = jsonResponse.message;
+                        }
+                    }
+                    catch(ignore)
+                    {
+                        // no-op
+                    }
                 }
 
                 Admin.removeClass(el('command-console-lastError'), 'hidden');


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR adds a command console tool supporting simple pluggability of command set extensions via a convention based web script URL discovery / execution approach. The initial command plugin provided adds some permission evaluation commands to check the effective permissions of a user on a specified node. In another branch (future PR) I have used this framework to also provide some low-level interactions with subsystems and their configuration. This command console tool can form the basis of integration various small, reusable tools that do not necessarily lend themselves to create fully fledged tool pages on their own.

### RELATED INFORMATION

Fixes #110