### PR TITLE
Bugfixes and dealing with subsystem implicit startup (Alfresco implementation flaw)

### DIFF
--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/config/PropertyBackedBeanPersister.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/config/PropertyBackedBeanPersister.java
@@ -290,10 +290,13 @@ public class PropertyBackedBeanPersister implements InitializingBean
     {
         final String name = this.lookupPropertyBackedBeanName(propertyBackedBean);
 
-        this.transactionService.getRetryingTransactionHelper().doInTransaction(() -> {
-            this.clearPropertiesInTransaction(name);
-            return null;
-        }, false, true);
+        if (permanent)
+        {
+            this.transactionService.getRetryingTransactionHelper().doInTransaction(() -> {
+                this.clearPropertiesInTransaction(name);
+                return null;
+            }, false, true);
+        }
 
         this.knownPropertyBackedBeanInstances.remove(new PropertyBackedBeanHolder(propertyBackedBean));
     }

--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/config/PropertyBackedBeanPersister.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/config/PropertyBackedBeanPersister.java
@@ -302,8 +302,15 @@ public class PropertyBackedBeanPersister implements InitializingBean
     {
         final Map<String, String> properties = this.getPersistedProperties(name);
         properties.keySet().removeIf(key -> !propertyBackedBean.isUpdateable(key));
-        propertyBackedBean.setProperties(properties);
-        LOGGER.debug("Initialised {} from persisted properties {}", name, properties);
+        if (!properties.isEmpty())
+        {
+            propertyBackedBean.setProperties(properties);
+            LOGGER.debug("Initialised {} from persisted properties {}", name, properties);
+        }
+        else
+        {
+            LOGGER.debug("No persisted properties exist for bean {}", name);
+        }
     }
 
     protected Map<String, String> getPersistedProperties(final String name)


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR addresses some bugs in the new feature of persistent subsystem configurations, and deals with an implementation flaw in Alfresco core, where subsystems are started whenever properties are set, regardless of their intended enablement state. Essentially, this change will ignore (but log) any AlfrescoRuntimeException during the initialisation from persisted properties, as such an exception is likely the result of an implicit start of a subsystem (such as Lucene in 5.0.d).

### RELATED INFORMATION

Bugs found and fixed as part of the overall solution include:

- No longer deleting persisted properties during shutdown (respecting the permanent flag on subsystem deregistration)
- Using reflection to deal with API incompabilities between Alfresco 5.2+ and earlier versions (specifically in multi-instance subsystems like Authentication / Search, which use a ChildApplicationContextManager)
- Minor JS validation fixes

Fixes #132 