### PR TITLE
Log file download for Repository log files do not work from Share.

### DIFF
--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/web/scripts/AbstractLogFileWebScript.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/web/scripts/AbstractLogFileWebScript.java
@@ -36,6 +36,7 @@ import org.apache.log4j.spi.LoggerRepository;
 import org.springframework.extensions.webscripts.AbstractWebScript;
 import org.springframework.extensions.webscripts.Status;
 import org.springframework.extensions.webscripts.WebScriptException;
+import org.springframework.extensions.webscripts.WebScriptRequest;
 
 /**
  *
@@ -174,6 +175,20 @@ public abstract class AbstractLogFileWebScript extends AbstractWebScript
             loggers.add(currentLoggers.nextElement());
         }
         return loggers;
+    }
+
+    protected String getFilePath(final WebScriptRequest req) {
+
+        final String servicePath = req.getServicePath();
+        final String matchPath = req.getServiceMatch().getPath();
+        String filePath = servicePath.substring(servicePath.indexOf(matchPath) + matchPath.length());
+
+        if(!filePath.startsWith("/")) {
+            filePath = "/" + filePath;
+        }
+
+        return filePath;
+
     }
 
 }

--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/web/scripts/LogFileDelete.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/web/scripts/LogFileDelete.java
@@ -42,9 +42,7 @@ public class LogFileDelete extends AbstractLogFileWebScript
     @Override
     public void execute(final WebScriptRequest req, final WebScriptResponse res) throws IOException
     {
-        final String servicePath = req.getServicePath();
-        final String matchPath = req.getServiceMatch().getPath();
-        final String filePath = servicePath.substring(servicePath.indexOf(matchPath) + matchPath.length());
+        final String filePath = getFilePath(req);
 
         final File file = this.validateFilePath(filePath);
         if (file.delete())

--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/web/scripts/LogFileGet.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/web/scripts/LogFileGet.java
@@ -55,9 +55,7 @@ public class LogFileGet extends AbstractLogFileWebScript
     @Override
     public void execute(final WebScriptRequest req, final WebScriptResponse res) throws IOException
     {
-        final String servicePath = req.getServicePath();
-        final String matchPath = req.getServiceMatch().getPath();
-        final String filePath = servicePath.substring(servicePath.indexOf(matchPath) + matchPath.length());
+        final String filePath = getFilePath(req);
 
         final Map<String, Object> model = new HashMap<>();
         final Status status = new Status();


### PR DESCRIPTION
Log file download for repository log files fails when downloaded from Alfresco Share support tools page.

### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This is due to the filePath in the request not being resolved to an
absolute path (no / in the start of string). With this, it fails to resolve
as a valid path to download from.

This is resolved by checking if it starts with /, if not add it.
Moved this into the AbstractLogFileWebScript to not duplicate code.

Could probably be resolved by fixing the substring, but it can be that
different browsers handle double slashes (that is actually in the
request from Share) differently. So using this method instead.

### RELATED INFORMATION

N/A

Fixes #

# BE WARNED

- If any of the checklist items are missed, incomplete or invalid we will not accept the PR
- If you are not responsive to feedback on your PR we will not accept the PR
- If we do not accept your PR we will provide feedback on the PR indicating why
- After some time, we will close PRs that have not been accepted

When we decline or close your PR. You are encouraged to address the concerns outlined in the
PR and then re-submit it. We want contributions. We also need for them to be of high quality
and high value and to not take undue resources away from the features and enhancements the
core team is working on. Thanks for understanding!
