### PR TITLE
Changed format of the Thread header of the thread dump

### DIFF
--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump-getone.get.html.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump-getone.get.html.ftl
@@ -28,7 +28,7 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
 
 <#if modelThreads?? && modelThreads?size gt 0>
     <#list modelThreads as modelThread>
-<span class="highlight">"${modelThread.threadName}" tid=${modelThread.threadId} Total_Blocked=${modelThread.blockedCount} Total_Waited=${modelThread.waitedCount} Waited_Time=${modelThread.waitedTime} ${modelThread.threadState}</span>
+<span class="highlight">"${modelThread.threadName}" Thread t@${modelThread.threadId} Total_Blocked=${modelThread.blockedCount} Total_Waited=${modelThread.waitedCount} Waited_Time=${modelThread.waitedTime} ${modelThread.threadState}</span>
    java.lang.Thread.State: ${modelThread.threadState}
         <#if modelThread.stackTrace??>
 ${modelThread.stackTrace}</#if>   Locked ownable synchronizers:


### PR DESCRIPTION
Changed format of the Thread header to make it compatible with other tools.

### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x ] There aren't existing pull requests attempting to address the issue mentioned here
- [x ] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

The current format of the thread dump is not compatible with the Spotify thread dump analyzer (https://spotify.github.io/threaddump-analyzer/).  

### RELATED INFORMATION

Spotify tries to identify each thread looking for one of several strings that typically mark the beginning of each thread's stack. For example, it looks for "Thread t@", "prio=", etc. I replaced the string "id=" with "Thread t@", so Spotify would recognize each thread.

A better fix would be to include the thread priority ("prio="), but that is not provided by runtimeMXBean (see thread-dump.lib.js)

Fixes #102 

