### PR TITLE
Add missing amp classifier in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Including the AMP artifact into an All-in-One project created from the archetype
     <artifactId>support-tools-repo</artifactId>
     <version>1.1.0.0</version>
     <type>amp</type>
+    <classifier>amp</classifier>
     <exclusions>
         <exclusion>
             <groupId>*</groupId>
@@ -63,6 +64,7 @@ Including the AMP artifact into an All-in-One project created from the archetype
     <artifactId>support-tools-share</artifactId>
     <version>1.1.0.0</version>
     <type>amp</type>
+    <classifier>amp</classifier>
     <exclusions>
         <exclusion>
             <groupId>*</groupId>


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This fixes a tiny oversight in the recent README update. The switch to SDK 4 and workaround to produce proper AMPs and JARs at the same time required the addition of the "amp" classifier to the AMP artifacts. This was not documentated in the README.