### PR TITLE
Remove obsolete section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Including the AMP artifact into an All-in-One project created from the archetype
 </dependency>
 ```
 
+## Artifact Repository and Building
+
+Releases of this addon are [published to Maven Central](https://mvnrepository.com/artifact/org.orderofthebee.support-tools) so you can use these artifacts in your Maven build without any extra configuration. If you want to use a SNAPSHOT build, clone this project and build it locally using:
+
+```
+mvn install
+```
+
 # Contributing
 
 We hope to have lots of collaborators on this project. As such, we have outlined our contribution policies and proceedures in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Including the AMP artifact into an All-in-One project created from the archetype
 
 ## Artifact Repository and Building
 
-Releases of this addon are [published to Maven Central](https://mvnrepository.com/artifact/org.orderofthebee.support-tools) so you can use these artifacts in your Maven build without any extra configuration. If you want to use a SNAPSHOT build, clone this project and build it locally using:
+Releases of this addon are [published to Maven Central](https://search.maven.org/search?q=g:org.orderofthebee.support-tools) so you can use these artifacts in your Maven build without any extra configuration. If you want to use a SNAPSHOT build, clone this project and build it locally using:
 
 ```
 mvn install

--- a/README.md
+++ b/README.md
@@ -74,14 +74,6 @@ Including the AMP artifact into an All-in-One project created from the archetype
 </dependency>
 ```
 
-## Artifact Repository and Building
-
-Currently this addon is not yet published to an artifact repository, so before you can use it you need to clone and build it locally using:
-
-```
-mvn install
-```
-
 # Contributing
 
 We hope to have lots of collaborators on this project. As such, we have outlined our contribution policies and proceedures in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.


### PR DESCRIPTION
### CHECKLIST

- [X] There aren't existing pull requests attempting to address the issue mentioned here
- [X] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION
The Support Tools are published to Maven Central, which is included in every maven build by default. The section on building and installing it locally in order to use it is no longer relevant, and may mislead people into thinking that this addon is harder to install than it actually is.
