### PR TITLE
Fix propertyBackedBeansPersister cache name to fit Caches tool lookup

### DIFF
--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/module-context.xml
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/module-context.xml
@@ -12,13 +12,13 @@
         </property>
     </bean>
 
-    <bean name="ootbee-support-tools.propertyBackedBeansPersister.sharedCache" factory-bean="cacheFactory" factory-method="createCache">
+    <bean name="propertyBackedBeansPersisterSharedCache" factory-bean="cacheFactory" factory-method="createCache">
         <constructor-arg value="cache.propertyBackedBeansPersisterSharedCache" />
     </bean>
 
-    <bean name="ootbee-support-tools.propertyBackedBeansPersister.txnCache" class="org.alfresco.repo.cache.TransactionalCache">
-        <property name="sharedCache" ref="ootbee-support-tools.propertyBackedBeansPersister.sharedCache" />
-        <property name="name" value="ootbee-support-tools.propertyBackedBeansPersister.txnCache" />
+    <bean name="propertyBackedBeansPersisterSharedCache.txnCache" class="org.alfresco.repo.cache.TransactionalCache">
+        <property name="sharedCache" ref="propertyBackedBeansPersisterSharedCache" />
+        <property name="name" value="propertyBackedBeansPersisterSharedCache.txnCache" />
         <property name="maxCacheSize" value="${cache.propertyBackedBeansPersisterSharedCache.tx.maxItems}" />
         <property name="mutable" value="true" />
         <property name="disableSharedCache" value="${system.cache.disableMutableSharedCaches}" />
@@ -33,7 +33,7 @@
         <property name="descriptorService" ref="DescriptorService" />
         <property name="transactionService" ref="TransactionService" />
         <property name="attributeService" ref="AttributeService" />
-        <property name="propertyBackedBeanPropertiesCache" ref="ootbee-support-tools.propertyBackedBeansPersister.txnCache" />
+        <property name="propertyBackedBeanPropertiesCache" ref="propertyBackedBeansPersisterSharedCache.txnCache" />
 
         <property name="enabled" value="${ootbee-support-tools.propertyBackedBeanPersister.enabled}" />
         <property name="useLegacyJmxKeysForRead"


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR fixes the name of the shared cache bean for the PropertyBackedBeansPersister to match the standard naming convention, which is used within the Caches tool to lookup configurations.

### RELATED INFORMATION

Fixes #149 

This PR already includes the changes for PR #153, so should only be merged after that PR, and would need to be rebased if that PR is rejected.