### PR TITLE
Fix display of cache statistics

### DIFF
--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.json.ftl
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.get.json.ftl
@@ -34,9 +34,9 @@ Copyright (C) 2005 - 2020 Alfresco Software Limited.
             <#if cacheInfo.maxSize &gt; 0>"maxSize": ${cacheInfo.maxSize?c},</#if>
             <#if cacheInfo.cacheGets &gt;= 0>"cacheGets": ${cacheInfo.cacheGets?c},</#if>
             <#if cacheInfo.cacheHits &gt;= 0>"cacheHits": ${cacheInfo.cacheHits?c},</#if>
-            <#if cacheInfo.cacheHitRate &gt;= 0>"cacheHitRate": ${cacheInfo.cacheHitRate?c},</#if>
+            <#if cacheInfo.cacheHitRate &gt;= 0>"cacheHitRate": ${cacheInfo.cacheHitRate?string["0.#"]},</#if>
             <#if cacheInfo.cacheMisses &gt;= 0>"cacheMisses": ${cacheInfo.cacheMisses?c},</#if>
-            <#if cacheInfo.cacheMissRate &gt;= 0>"cacheMissRate": ${cacheInfo.cacheMissRate?c},</#if>
+            <#if cacheInfo.cacheMissRate &gt;= 0>"cacheMissRate": ${cacheInfo.cacheMissRate?string["0.#"]},</#if>
             <#if cacheInfo.cacheEvictions &gt;= 0>"cacheEvictions": ${cacheInfo.cacheEvictions?c},</#if>
             "clearable": ${cacheInfo.clearable?string}
         }<#if cacheInfo_has_next>,</#if>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/caches.lib.js
@@ -117,12 +117,21 @@ function buildCacheInfo(cacheName, cache, allowClearGlobal, propertyGetter)
             case 'org.alfresco.repo.cache.DefaultSimpleCache':
                 stats = Packages.org.orderofthebee.addons.support.tools.repo.caches.CacheLookupUtils.getDefaultSimpleCacheStats(cache);
 
-                cacheInfo.cacheGets = stats.requestCount();
-                cacheInfo.cacheHits = stats.hitCount();
-                cacheInfo.cacheMisses = stats.missCount();
-                cacheInfo.cacheEvictions = stats.evictionCount();
-                cacheInfo.cacheHitRate = stats.hitRate() * 100;
-                cacheInfo.cacheMissRate = stats.missRate() * 100;
+                if ((stats === null || stats.requestCount() === 0) && alfCacheStats !== undefined && alfCacheStats !== null)
+                {
+                    // fallback to Alfresco cache statistics
+                    // (DefaultSimpleCache in most/all Alfresco version uses Google cache with stats disabled)
+                    mapCacheMetrics(alfCacheStats, cacheInfo);
+                }
+                else if (stats !== null)
+                {
+                    cacheInfo.cacheGets = stats.requestCount();
+                    cacheInfo.cacheHits = stats.hitCount();
+                    cacheInfo.cacheMisses = stats.missCount();
+                    cacheInfo.cacheEvictions = stats.evictionCount();
+                    cacheInfo.cacheHitRate = stats.hitRate() * 100;
+                    cacheInfo.cacheMissRate = stats.missRate() * 100;
+                }
 
                 cacheInfo.clearable = cacheInfo.clearable
                         && propertyGetter('ootbee-support-tools.cache.default.clearable', '').toLowerCase() === 'true';
@@ -130,12 +139,21 @@ function buildCacheInfo(cacheName, cache, allowClearGlobal, propertyGetter)
             case 'org.alfresco.enterprise.repo.cluster.cache.InvalidatingCache':
                 stats = Packages.org.orderofthebee.addons.support.tools.repo.caches.CacheLookupUtils.getHzInvalidatingCacheStats(cache);
 
-                cacheInfo.cacheGets = stats.requestCount();
-                cacheInfo.cacheHits = stats.hitCount();
-                cacheInfo.cacheMisses = stats.missCount();
-                cacheInfo.cacheEvictions = stats.evictionCount();
-                cacheInfo.cacheHitRate = stats.hitRate() * 100;
-                cacheInfo.cacheMissRate = stats.missRate() * 100;
+                if ((stats === null || stats.requestCount() === 0) && alfCacheStats !== undefined && alfCacheStats !== null)
+                {
+                    // fallback to Alfresco cache statistics
+                    // (DefaultSimpleCache in most/all Alfresco version uses Google cache with stats disabled)
+                    mapCacheMetrics(alfCacheStats, cacheInfo);
+                }
+                else if (stats !== null)
+                {
+                    cacheInfo.cacheGets = stats.requestCount();
+                    cacheInfo.cacheHits = stats.hitCount();
+                    cacheInfo.cacheMisses = stats.missCount();
+                    cacheInfo.cacheEvictions = stats.evictionCount();
+                    cacheInfo.cacheHitRate = stats.hitRate() * 100;
+                    cacheInfo.cacheMissRate = stats.missRate() * 100;
+                }
 
                 cacheInfo.clearable = cacheInfo.clearable
                         && propertyGetter('ootbee-support-tools.cache.invalidating.clearable', '').toLowerCase() === 'true';
@@ -150,7 +168,7 @@ function buildCacheInfo(cacheName, cache, allowClearGlobal, propertyGetter)
                     // fallback to Alfresco cache statistics
                     mapCacheMetrics(alfCacheStats, cacheInfo);
                 }
-                else
+                else if (stats !== null)
                 {
                     cacheInfo.cacheGets = stats.operationStats.numberOfGets;
                     // cacheInfo.cacheHits = stats.hits;
@@ -168,24 +186,15 @@ function buildCacheInfo(cacheName, cache, allowClearGlobal, propertyGetter)
                 if (cache.metrics !== undefined && cache.metrics !== null)
                 {
                     mapCacheMetrics(cache.metrics, cacheInfo);
-                    cacheInfo.clearable = cacheInfo.clearable
-                            && propertyGetter('ootbee-support-tools.cache.' + cacheInfo.type + '.clearable',
-                                    propertyGetter('ootbee-support-tools.cache.unknown.clearable', '')).toLowerCase() === 'true';
                 }
                 else if (alfCacheStats !== undefined && alfCacheStats !== null)
                 {
                     // fallback to Alfresco cache statistics
                     mapCacheMetrics(alfCacheStats, cacheInfo);
-                    cacheInfo.clearable = cacheInfo.clearable
-                            && propertyGetter('ootbee-support-tools.cache.' + cacheInfo.type + '.clearable',
-                                    propertyGetter('ootbee-support-tools.cache.unknown.clearable', '')).toLowerCase() === 'true';
                 }
-                else
-                {
-                    cacheInfo.clearable = cacheInfo.clearable
-                            && propertyGetter('ootbee-support-tools.cache.' + cacheInfo.type + '.clearable',
-                                    propertyGetter('ootbee-support-tools.cache.unknown.clearable', '')).toLowerCase() === 'true';
-                }
+                cacheInfo.clearable = cacheInfo.clearable
+                        && propertyGetter('ootbee-support-tools.cache.' + cacheInfo.type + '.clearable',
+                                propertyGetter('ootbee-support-tools.cache.unknown.clearable', '')).toLowerCase() === 'true';
         }
     }
     catch (e)


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR fixes the display of cache statistics, especially with regards to default Alfresco caches. Fixes include:

- fallback to Alfresco transactional cache stats if Google cache internal stats don't record anything (disabled in of most or all Alfresco versions)
- consistent rounding of hit / miss rates to at most one decimal place
- correct double handling in hit / miss percentage math within our AlfrescoCacheStatsFacade (used to end up as either 100 or 0% due to integer-only division)
- improved safeguards + fallbacks for cases of potential reflection-inaccessible cache stats in Java 9+

### RELATED INFORMATION

Fixes #137