### PR TITLE
Improve handling of absolute log file paths

### DIFF
--- a/repository/src/main/resources/META-INF/resources/ootbee-support-tools/js/log-files.js
+++ b/repository/src/main/resources/META-INF/resources/ootbee-support-tools/js/log-files.js
@@ -70,6 +70,14 @@ Admin.addEventListener(window, 'load', function()
             pathFragments[idx] = encodeURIComponent(pathFragments[idx]).replace(/:/g, '%3A');
         }
         realPath = pathFragments.join('/');
+        // cleanup any duplicate slashes
+        realPath = realPath.replace(/\/+/g, '/');
+        // path should not start with a slash to avoid double-slash in URL
+        // (leading slash will be re-added as part of file path resolution in backend)
+        if (realPath.substr(0, 1) === '/')
+        {
+            realPath = realPath.substr(1);
+        }
 
         Admin.request({
             url : serviceContext + '/ootbee/admin/log4j-log-file/' + realPath,

--- a/share/src/main/java/org/orderofthebee/addons/support/tools/share/LogFileGet.java
+++ b/share/src/main/java/org/orderofthebee/addons/support/tools/share/LogFileGet.java
@@ -44,9 +44,7 @@ public class LogFileGet extends AbstractLogFileWebScript
     @Override
     public void execute(final WebScriptRequest req, final WebScriptResponse res) throws IOException
     {
-        final String servicePath = req.getServicePath();
-        final String matchPath = req.getServiceMatch().getPath();
-        final String filePath = servicePath.substring(servicePath.indexOf(matchPath) + matchPath.length());
+        final String filePath = this.getFilePath(req);
 
         final Map<String, Object> model = new HashMap<>();
         final Status status = new Status();
@@ -58,6 +56,21 @@ public class LogFileGet extends AbstractLogFileWebScript
         final boolean attach = attachParam != null && Boolean.parseBoolean(attachParam);
 
         this.logFileHandler.handleLogFileRequest(filePath, attach, req, res, model);
+    }
+
+    protected String getFilePath(final WebScriptRequest req)
+    {
+        final String servicePath = req.getServicePath();
+        final String matchPath = req.getServiceMatch().getPath();
+        String filePath = servicePath.substring(servicePath.indexOf(matchPath) + matchPath.length());
+
+        if (!filePath.startsWith("/"))
+        {
+            filePath = "/" + filePath;
+        }
+
+        return filePath;
+
     }
 
 }

--- a/share/src/main/java/org/orderofthebee/addons/support/tools/share/LogFileGetServlet.java
+++ b/share/src/main/java/org/orderofthebee/addons/support/tools/share/LogFileGetServlet.java
@@ -107,8 +107,12 @@ public class LogFileGetServlet extends HttpServlet
         if (user != null && user.isAdmin())
         {
             final String requestURI = req.getRequestURI();
-            final String filePath = URLDecoder
+            String filePath = URLDecoder
                     .decode(requestURI.substring(req.getContextPath().length() + req.getServletPath().length() + 1));
+            if (!filePath.startsWith("/"))
+            {
+                filePath = "/" + filePath;
+            }
 
             final Map<String, Object> model = new HashMap<>();
             final Status status = new Status();

--- a/share/src/main/resources/META-INF/resources/ootbee-support-tools/service/LogFileService.js
+++ b/share/src/main/resources/META-INF/resources/ootbee-support-tools/service/LogFileService.js
@@ -1,20 +1,15 @@
 /**
  * Copyright (C) 2016 - 2020 Order of the Bee
- *
+ * 
  * This file is part of OOTBee Support Tools
- *
- * OOTBee Support Tools is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
- *
- * OOTBee Support Tools is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
- * General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with OOTBee Support Tools. If not, see
+ * 
+ * OOTBee Support Tools is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ * 
+ * OOTBee Support Tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with OOTBee Support Tools. If not, see
  * <http://www.gnu.org/licenses/>.
  */
 /*
@@ -79,7 +74,7 @@ define([ 'dojo/_base/declare', 'alfresco/services/BaseService', 'alfresco/core/C
                     'accept-charset' : 'utf-8',
                     style : 'display:none'
                 }, document.body);
-                
+
                 array.forEach(payload.selectedItems, lang.hitch(this,
                         function ootbeeSupportTools_service_LogFileService__onDownloadLogFilesZip_forEachSelectedItem(logFile)
                         {
@@ -199,6 +194,14 @@ define([ 'dojo/_base/declare', 'alfresco/services/BaseService', 'alfresco/core/C
                     pathFragments[idx] = encodeURIComponent(pathFragments[idx]).replace(/:/g, '%3A');
                 }
                 path = pathFragments.join('/');
+                // cleanup any duplicate slashes
+                path = path.replace(/\/+/g, '/');
+                // path should not start with a slash to avoid double-slash in URL
+                // (leading slash will be re-added as part of file path resolution in backend)
+                if (path.substr(0, 1) === '/')
+                {
+                    path = path.substr(1);
+                }
             }
 
             return path;

--- a/share/src/main/resources/alfresco/messages/ootbee-support-tools_de.properties
+++ b/share/src/main/resources/alfresco/messages/ootbee-support-tools_de.properties
@@ -47,7 +47,7 @@ log-settings.tail.message=Nachricht
 
 log-settings.files.name=Dateiname
 log-settings.files.path=Pfad
-log-settings.files.size=Gr\u00f6\00dfe
+log-settings.files.size=Gr\u00f6\u00dfe
 log-settings.files.lastModified=Last modified
 
 log-settings.files.selected-items.label=Ausgew\u00e4hlte Elemente...


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR addresses issues with absolute log file paths during log file download. Client side adaptions have been made to avoid double-slash URLs being constructed and the server-side log file path resolution has been made consistent for all three cases (Repository web script, Share servlet + web script).

### RELATED INFORMATION

Fixes #139