### PR TITLE
Fix job state correlation for auto-/unnamed jobs

### DIFF
--- a/repository/src/main/resources/META-INF/resources/ootbee-support-tools/js/scheduled-jobs.js
+++ b/repository/src/main/resources/META-INF/resources/ootbee-support-tools/js/scheduled-jobs.js
@@ -105,7 +105,7 @@ Admin.addEventListener(window, 'load', function()
                     {
                         jobRow = jobRows[rowIdx];
                         nameCell = jobRow.cells.namedItem('jobName');
-                        jobName = nameCell.innerHTML;
+                        jobName = nameCell.getAttribute('data-technicalName');
                         groupCell = jobRow.cells.namedItem('jobGroup');
                         jobGroup = groupCell.innerHTML;
                         stateCell = jobRow.cells.namedItem('jobState');

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/scheduled-jobs.get.html.ftl
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/scheduled-jobs.get.html.ftl
@@ -66,19 +66,19 @@ Copyright (C) 2005 - 2020 Alfresco Software Limited.
                         msg('scheduled-jobs.table-header.trigger-state.blocked')] />
                     <#list jobTriggers as trigger>
                         <tr id="${trigger.triggerName?html}">
-                            <td id="triggerName">${trigger.triggerName?html}</td>
-                            <td id="triggerGroup">${trigger.triggerGroup?html}</td>
+                            <td name="triggerName">${trigger.triggerName?html}</td>
+                            <td name="triggerGroup">${trigger.triggerGroup?html}</td>
                             <#-- offset by one as states have value space -1 (none) to 4 (blocked) -->
-                            <td id="triggerState">${stateMessages[trigger.triggerState]?html}</td>
-                            <td id="jobName">${(trigger.jobDisplayName!"")?html}</td>
-                            <td id="jobGroup">${trigger.jobGroup?html}</td>
-                            <td id="jobState">
+                            <td name="triggerState">${stateMessages[trigger.triggerState]?html}</td>
+                            <td name="jobName" data-technicalName="${trigger.jobName?html}">${(trigger.jobDisplayName!"")?html}</td>
+                            <td name="jobGroup">${trigger.jobGroup?html}</td>
+                            <td name="jobState">
                                  ${msg(trigger.running?string("scheduled-jobs.state.running", "scheduled-jobs.state.notRunning"))?html}
                             </td>
                             <td title="${(trigger.cronExpressionDescription!"")?html}">${(trigger.cronExpression!"")?html}</td>
-                            <td id="jobStartTime"><#if trigger.startTime??>${xmldate(trigger.startTime)?html}</#if></td>
-                            <td id="jobPreviousFire"><#if trigger.previousFireTime??>${xmldate(trigger.previousFireTime)?html}</#if></td>
-                            <td id="jobNextFire"><#if trigger.nextFireTime??>${xmldate(trigger.nextFireTime)?html}</#if></td>
+                            <td name="jobStartTime"><#if trigger.startTime??>${xmldate(trigger.startTime)?html}</#if></td>
+                            <td name="jobPreviousFire"><#if trigger.previousFireTime??>${xmldate(trigger.previousFireTime)?html}</#if></td>
+                            <td name="jobNextFire"><#if trigger.nextFireTime??>${xmldate(trigger.nextFireTime)?html}</#if></td>
                             <td>${(trigger.timeZone!"")?html}</td>
                             <td>
                                 <p><a href="#" onclick="Admin.showDialog('${url.serviceContext}/ootbee/admin/scheduled-jobs-execute?jobName=${trigger.jobName?url('UTF-8')}&amp;groupName=${trigger.jobGroup?url('UTF-8')}');">${msg("scheduled-jobs.execute-now")?html}</a></p>


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR addresses the issue that ever since Alfresco 6.0 and its changes to how jobs are registered, some jobs may not have explicitly set names that can be matched when checking the jobs currently being processed and correlating them with the jobs displayed in the UI, as we were dropping the technical name due to its seeming lack of worth to the end user. This PR adds an additional HTML data attribute to keep track of the technical name, so that our recurring client poll to check active jobs can locate the affected jobs and update their status accordingly.
Somewhat related to this change, the incorrectly used ID attributes (supposed to be unique but definitely ambigiuous in our implementation) were replace by name attributes that don't have to comply with similar global uniquess requirements as element IDs.

### RELATED INFORMATION

Fixes #127