### PR TITLE
(#165) Add favicon to admin page template

### DIFF
--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/admin-template.ftl
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/admin-template.ftl
@@ -55,6 +55,8 @@ Copyright (C) 2005 - 2020 Alfresco Software Limited.
 <head>
    <title>Alfresco &raquo; ${title?html}<#if metadata??> [${HOSTNAME} ${HOSTADDR}]</#if></title>
    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+   <link rel="shortcut icon" href="${url.context}/favicon.ico" type="image/vnd.microsoft.icon" />
+   <link rel="icon" href="${url.context}/favicon.ico" type="image/vnd.microsoft.icon" />
    <link rel="stylesheet" type="text/css" href="${url.context}/css/reset.css" />
    <link rel="stylesheet" type="text/css" href="${url.context}/css/alfresco.css" />
    <link rel="stylesheet" type="text/css" href="${url.context}/admin/css/admin.css" />


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR enhances the Repository-tier admin console page template to include the Alfresco favicon, so that pages don't inherit any favicons from parent contexts.

### RELATED INFORMATION

Fixes #165