### PR TITLE
Add copy-to-clipboard action for thread dumps

### DIFF
--- a/repository/src/main/resources/META-INF/resources/ootbee-support-tools/js/threads.js
+++ b/repository/src/main/resources/META-INF/resources/ootbee-support-tools/js/threads.js
@@ -54,21 +54,45 @@ Admin.addEventListener(window, 'load', function()
     {
         toolName = newToolName;
     };
+    
+    AdminTD.copyToClipboard = function copyToClipBoard(toSave)
+    {
+        var textToWrite, dump, tDump, area;
+
+        textToWrite = '';
+        dump = el(toSave);
+        if (dump)
+        {
+            tDump = dump.innerHTML;
+            textToWrite += tDump + '\n';
+        }
+
+        textToWrite = textToWrite.replace(/<\/?span[^>]*>/g, '');
+        textToWrite = textToWrite.replace(/&lt;/g, '<');
+        textToWrite = textToWrite.replace(/&gt;/g, '>');
+        
+        area = document.createElement('textarea');
+        area.value = textToWrite;
+        document.body.appendChild(area);
+        area.select();
+        document.execCommand('copy');
+        document.body.removeChild(area);
+    };
 
     AdminTD.saveTextAsFile = function saveTextAsFile(toSave)
     {
         var textToWrite, allDumps, i, tDump, dump, textFileAsBlob, fileNameToSaveAs, ie, ieVer, ie11, downloadLink;
 
-        textToWrite = "";
+        textToWrite = '';
 
-        if (toSave === "all")
+        if (toSave === 'all')
         {
-            allDumps = document.getElementsByClassName("thread");
+            allDumps = document.getElementsByClassName('thread');
 
             for (i = 0; i < allDumps.length; i++)
             {
                 tDump = allDumps[i].innerHTML;
-                textToWrite += tDump + "\n";
+                textToWrite += tDump + '\n';
             }
         }
         else
@@ -77,20 +101,18 @@ Admin.addEventListener(window, 'load', function()
             if (dump)
             {
                 tDump = dump.innerHTML;
-                textToWrite += tDump + "\n";
+                textToWrite += tDump + '\n';
             }
         }
 
-        textToWrite = textToWrite.replace(/<span id="date" class="highlight">/g, "");
-        textToWrite = textToWrite.replace(/<span class="highlight">/g, "");
-        textToWrite = textToWrite.replace(/<\/span>/g, "");
-        textToWrite = textToWrite.replace(/&lt;/g, "<");
-        textToWrite = textToWrite.replace(/&gt;/g, ">");
+        textToWrite = textToWrite.replace(/<\/?span[^>]*>/g, '');
+        textToWrite = textToWrite.replace(/&lt;/g, '<');
+        textToWrite = textToWrite.replace(/&gt;/g, '>');
 
         textFileAsBlob = new Blob([ textToWrite ], {
             type : 'text/plain'
         });
-        fileNameToSaveAs = toolName + ".txt";
+        fileNameToSaveAs = toolName + '.txt';
 
         ie = navigator.userAgent.match(/MSIE\s([\d.]+)/);
         ie11 = navigator.userAgent.match(/Trident\/7.0/) && navigator.userAgent.match(/rv:11/);
@@ -99,7 +121,7 @@ Admin.addEventListener(window, 'load', function()
         if (ie && ieVer < 10)
         {
             // TODO I18n
-            alert("No blobs on IE ver < 10");
+            alert('No blobs on IE ver < 10');
             return;
         }
 
@@ -109,11 +131,11 @@ Admin.addEventListener(window, 'load', function()
         }
         else
         {
-            downloadLink = document.createElement("a");
+            downloadLink = document.createElement('a');
 
             downloadLink.download = fileNameToSaveAs;
             // TODO I18n
-            downloadLink.innerHTML = "Download File";
+            downloadLink.innerHTML = 'Download File';
 
             if (window.webkitURL)
             {
@@ -126,7 +148,7 @@ Admin.addEventListener(window, 'load', function()
                 // Firefox requires the link to be added to the DOM
                 // before it can be clicked.
                 downloadLink.href = window.URL.createObjectURL(textFileAsBlob);
-                downloadLink.style.display = "none";
+                downloadLink.style.display = 'none';
                 document.body.appendChild(downloadLink);
             }
 
@@ -138,31 +160,32 @@ Admin.addEventListener(window, 'load', function()
     {
         var allTabs, i, selectors;
 
-        allTabs = document.getElementsByClassName("thread");
+        allTabs = document.getElementsByClassName('thread');
         for (i = 0; i < allTabs.length; i++)
         {
             if (allTabs[i].id === tabName)
             {
-                Admin.removeClass(allTabs[i], "hidden");
+                Admin.removeClass(allTabs[i], 'hidden');
             }
             else
             {
-                Admin.addClass(allTabs[i], "hidden");
+                Admin.addClass(allTabs[i], 'hidden');
             }
         }
 
-        selectors = document.getElementsByClassName("selector");
+        selectors = document.getElementsByClassName('selector');
 
         for (i = 0; i < selectors.length; i++)
         {
-            if (selectors[i].id === "s" + tabName)
+            if (selectors[i].id === 's' + tabName)
             {
-                Admin.addClass(selectors[i], "selected");
-                el("savecurrent").setAttribute("onclick", "AdminTD.saveTextAsFile('" + tabName + "');");
+                Admin.addClass(selectors[i], 'selected');
+                el('copycurrent').setAttribute('onclick', 'AdminTD.copyToClipboard("' + tabName + '");');
+                el('savecurrent').setAttribute('onclick', 'AdminTD.saveTextAsFile("' + tabName + '");');
             }
             else
             {
-                Admin.removeClass(selectors[i], "selected");
+                Admin.removeClass(selectors[i], 'selected');
             }
         }
     };
@@ -170,28 +193,28 @@ Admin.addEventListener(window, 'load', function()
     AdminTD.getDump = function getDump()
     {
         Admin.request({
-            url : serviceContext + "/ootbee/admin/" + encodeURIComponent(toolName) + "-getone.html",
-            requestContentType : "text/html",
-            responseContentType : "text/html",
+            url : serviceContext + '/ootbee/admin/' + encodeURIComponent(toolName) + '-getone.html',
+            requestContentType : 'text/html',
+            responseContentType : 'text/html',
             fnSuccess : function(res)
             {
                 var counter, viewer, control, firstDel, secondDel, tabTitle;
                 if (res.responseText)
                 {
-                    counter = document.getElementsByClassName("thread").length;
-                    viewer = document.getElementById("viewer");
-                    control = document.getElementById("control");
+                    counter = document.getElementsByClassName('thread').length;
+                    viewer = document.getElementById('viewer');
+                    control = document.getElementById('control');
                     // Find the date in the response text:
-                    firstDel = res.responseText.indexOf(">", res.responseText.indexOf("id=\"date\""));
-                    secondDel = res.responseText.indexOf("<", firstDel);
+                    firstDel = res.responseText.indexOf('>', res.responseText.indexOf('id="date"'));
+                    secondDel = res.responseText.indexOf('<', firstDel);
                     tabTitle = res.responseText.substr(firstDel + 1, secondDel - (firstDel + 1));
 
                     viewer.innerHTML = viewer.innerHTML
-                            + res.responseText.replace("__id__", "td" + counter).replace("__class__", "thread hidden");
-                    control.innerHTML = control.innerHTML + "<input type=\"button\" class=\"selector\" value=\"" + tabTitle + "\" id=\"std"
-                            + counter + "\" onclick=\"AdminTD.showTab('td" + counter + "');\" /> ";
+                            + res.responseText.replace('__id__', 'td' + counter).replace('__class__', 'thread hidden');
+                    control.innerHTML = control.innerHTML + '<input type="button" class="selector" value="' + tabTitle + '" id="std'
+                            + counter + '" onclick="AdminTD.showTab(\'td' + counter + '\');" />';
 
-                    AdminTD.showTab("td" + counter);
+                    AdminTD.showTab('td' + counter);
                 }
             }
         });

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get.html.ftl
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get.html.ftl
@@ -34,6 +34,7 @@ Copyright (C) 2005 - 2020 Alfresco Software Limited.
         <p class="intro">${msg("threaddump.intro-text")?html}</p>
 
         <@button label=msg("threaddump.get-another") onclick="AdminTD.getDump();"/>
+        <@button id="copycurrent" class="copy" label=msg("threaddump.copycurrent") onclick="AdminTD.copyToClipboard('current');"/>
         <@button id="savecurrent" class="save" label=msg("threaddump.savecurrent") onclick="AdminTD.saveTextAsFile('current');"/>
         <@button class="save" label=msg("threaddump.saveall") onclick="AdminTD.saveTextAsFile('all');"/>
 

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get.properties
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get.properties
@@ -2,4 +2,5 @@ threaddump.title=Thread Dump
 threaddump.intro-text=View and save thread dumps.
 threaddump.get-another=Get Another Thread Dump
 threaddump.saveall=Save All
+threaddump.copycurrent=Copy Current Thread to Clipboard
 threaddump.savecurrent=Save Current Thread

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get_de.properties
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get_de.properties
@@ -1,5 +1,6 @@
 threaddump.title=Prozessabbild
 threaddump.intro-text=Hier k\u00f6nnen Sie Prozessabbilder erstellen und speichern.
 threaddump.get-another=Weiteres Abbild erstellen
-threaddump.saveall=Alles Speichern
-threaddump.savecurrent=Aktuelles Abbild Speichern
+threaddump.saveall=Alle speichern
+threaddump.copycurrent=Aktuelles Abbild in Zwischenablage kopieren
+threaddump.savecurrent=Aktuelles Abbild speichern

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get_en.properties
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get_en.properties
@@ -2,4 +2,5 @@ threaddump.title=Thread Dump
 threaddump.intro-text=View and save thread dumps.
 threaddump.get-another=Get Another Thread Dump
 threaddump.saveall=Save All
+threaddump.copycurrent=Copy Current Thread to Clipboard
 threaddump.savecurrent=Save Current Thread

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get_es.properties
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get_es.properties
@@ -2,4 +2,5 @@ threaddump.title=Thread Dump
 threaddump.intro-text=Ver y salvar Thread Dumps (Volcados de hilos).
 threaddump.get-another=Obtener un Thread Dump
 threaddump.saveall=Salvar Todo
+threaddump.copycurrent=Copy Current Thread to Clipboard
 threaddump.savecurrent=Salvar este Thread Dump

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get_it.properties
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get_it.properties
@@ -2,4 +2,5 @@ threaddump.title=Dump del Thread
 threaddump.intro-text=Visualizza e salva i dump del thread 
 threaddump.get-another=Ottieni un altro dump del  Thread
 threaddump.saveall=Salva Tutto
+threaddump.copycurrent=Copy Current Thread to Clipboard
 threaddump.savecurrent=Salva il thread corrente

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get_pt.properties
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump.get_pt.properties
@@ -2,4 +2,5 @@ threaddump.title=Dump de Thread
 threaddump.intro-text=Visualizar e salvar dumps de threads.
 threaddump.get-another=Obter outro Dump de Thread
 threaddump.saveall=Salvar Tudo
+threaddump.copycurrent=Copy Current Thread to Clipboard
 threaddump.savecurrent=Salvar Thread Atual


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR adds a copy-to-clipboard action to the thread dump tooling to make it easier to take the thread dump and put it into some external thread dump analysis tooling, like the [Spotify Thread Dump Analyser](http://spotify.github.io/threaddump-analyzer/)

### RELATED INFORMATION

This PR does not fix a specific issue, but might be able to help support the use case expressed in #141