### PR TITLE
(#181) Add missing string concatenation for native methods

### DIFF
--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/threads-common.lib.js
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/threads-common.lib.js
@@ -39,7 +39,7 @@ function stackTrace(stacks, lockedMonitors, thisThread)
 
         if (stack.nativeMethod === true)
         {
-            stackTrace = "\tat " + stack.className + "." + stack.methodName + "(Native Method)\n";
+            stackTrace += "\tat " + stack.className + "." + stack.methodName + "(Native Method)\n";
 
             if (thisThread.lockInfo)
             {


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR fixes a bug with the thread dump-based tools which cut off stack traces at the highest level native method in the stack, just because a string concatenation was missing when handling native methods.

### RELATED INFORMATION

Fixes #181