### PR TITLE
Add two clearable caches

### DIFF
--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
@@ -65,8 +65,11 @@ cache.readersDeniedSharedCache.clearable=true
 cache.nodeOwnerSharedCache.clearable=true
 cache.nodeRulesSharedCache.clearable=true
 cache.personSharedCache.clearable=true
-# clearing the tickets cache will effectively invalidate all active user sessions
+cache.protectedUsersCache.clearable=true
+# clearing either ticket caches will effectively invalidate all active user sessions
+# usernameToTicketIdCache only in ACS 7.0+ as optimisation
 cache.ticketsCache.clearable=true
+cache.usernameToTicketIdCache.clearable=true
 cache.authorityEntitySharedCache.clearable=true
 cache.aclSharedCache.clearable=true
 cache.aclEntitySharedCache.clearable=true


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR adds two caches to the set of clearable caches - one new ACS 7.0 cache and the already existing protected user cache, allowing a hard reset of the brute force protection mechanism.

### RELATED INFORMATION

Fixes #178 