### PR TITLE
Fix DBCP2 incompatibilities for active-sessions in ACS 7.2

### DIFF
--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.lib.js
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions.lib.js
@@ -33,11 +33,11 @@ function buildConnectionPoolData()
     connectionPoolData = {
         initialSize : dataSource.initialSize,
         numActive : dataSource.numActive,
-        maxActive : dataSource.maxActive,
+        maxActive : dataSource.maxActive || dataSource.maxTotal, // dbcp2 renamed the property
         minIdle : dataSource.minIdle,
         numIdle : dataSource.numIdle,
         maxIdle : dataSource.maxIdle,
-        maxWait : dataSource.maxWait,
+        maxWait : dataSource.maxWait || dataSource.maxWaitMillis, // dbcp2 renamed the property
         url : dataSource.url,
         driverClassName : dataSource.driverClassName
     };


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR fixes compatibility of the active-sessions tool with API changes in DBCP2 which is included in ACS 7.2

### RELATED INFORMATION

