### PR TITLE
Improved protection for system + env variables

### DIFF
--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
@@ -1,4 +1,4 @@
-ootbee-support-tools.systeminformation.sensitiveKeys=api.key,password,secret
+ootbee-support-tools.systeminformation.sensitiveKeys=api.key,password,secret,keydata,credentials
 
 ootbee-support-tools.propertyBackedBeanPersister.enabled=true
 ootbee-support-tools.propertyBackedBeanPersister.useLegacyJmxKeysForRead=true

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/subsystem-commands.post.json.ftl
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/subsystem-commands.post.json.ftl
@@ -32,7 +32,7 @@ Copyright (C) 2005 - 2020 Alfresco Software Limited.
                 "listInstances",
                 "\t${msg("ootbee-support-tools.command-console.subsystems.listInstances.description")}",
                 "",
-                "listProperties <instanceId>",
+                "listProperties <instanceId> (withSensitiveValues)?",
                 "\t${msg("ootbee-support-tools.command-console.subsystems.listProperties.description")}",
                 "",
                 "setProperty <instanceId> <key>=<value>",


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR improves the protection of sensitive config properties in the System Information tools, specifically adding handling for Java arguments, system variables, and environment variables, specifically handling multiple `-D` props within env variables such as `JAVA_OPTS` / `JAVA_TOOL_OPTS` which will contain i.e. keystore in Alfresco's default images. This PR also extends the list of sensitive keys to include anything relating to credentials (i.e. LDAP credentials) and key data (if provided for Alfresco's automatic keystore creation). The same protection is also added to the Subsystems plugin for the Command Console when properties are listed, unless a new optional command parameter `withSensitiveValues` is specified.

### RELATED INFORMATION

Fixes #179