### PR TITLE
Adapt to scope unset in latest Alfresco security fixes

### DIFF
--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/jsconsole/ExecuteWebscript.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/jsconsole/ExecuteWebscript.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.alfresco.model.ContentModel;
 import org.alfresco.repo.cache.SimpleCache;
 import org.alfresco.repo.content.MimetypeMap;
 import org.alfresco.repo.jscript.RhinoScriptProcessor;
@@ -53,6 +54,8 @@ import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.security.permissions.AccessDeniedException;
 import org.alfresco.scripts.ScriptResourceHelper;
 import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.security.PermissionService;
 import org.alfresco.service.transaction.TransactionService;
 import org.alfresco.util.MD5;
 import org.alfresco.util.Pair;
@@ -90,6 +93,10 @@ public class ExecuteWebscript extends AbstractWebScript
     private ScriptUtils scriptUtils;
 
     private TransactionService transactionService;
+
+    private NodeService nodeService;
+
+    private PermissionService permissionService;
 
     private String postRollScript = "";
 
@@ -443,10 +450,12 @@ public class ExecuteWebscript extends AbstractWebScript
             }
 
             final ScriptNode newSpace = javascriptConsole.getSpace();
-            output.setSpaceNodeRef(newSpace.getNodeRef().toString());
+            final NodeRef newSpaceRef = newSpace.getNodeRef();
+            output.setSpaceNodeRef(newSpaceRef.toString());
             try
             {
-                output.setSpacePath(newSpace.getDisplayPath() + "/" + newSpace.getName());
+                output.setSpacePath(this.nodeService.getPath(newSpaceRef).toDisplayPath(this.nodeService, this.permissionService) + "/"
+                        + this.nodeService.getProperty(newSpaceRef, ContentModel.PROP_NAME));
             }
             catch (final AccessDeniedException ade)
             {
@@ -560,6 +569,16 @@ public class ExecuteWebscript extends AbstractWebScript
     public void setTransactionService(final TransactionService transactionService)
     {
         this.transactionService = transactionService;
+    }
+
+    public void setNodeService(final NodeService nodeService)
+    {
+        this.nodeService = nodeService;
+    }
+
+    public void setPermissionService(final PermissionService permissionService)
+    {
+        this.permissionService = permissionService;
     }
 
     public void setJsProcessor(final org.alfresco.service.cmr.repository.ScriptProcessor jsProcessor)

--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/module-context.xml
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/module-context.xml
@@ -93,6 +93,8 @@
         class="org.orderofthebee.addons.support.tools.repo.jsconsole.ExecuteWebscript" parent="webscript">
         <property name="scriptUtils" ref="utilsScript" />
         <property name="transactionService" ref="TransactionService" />
+        <property name="nodeService" ref="NodeService" />
+        <property name="permissionService" ref="PermissionService" />
         <property name="jsProcessor" ref="javaScriptProcessor" />
         <property name="printOutputCache" ref="jsConsoleOutput" />
         <property name="resultCache" ref="jsConsoleResult" />


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR addresses a NullPointerException that is occurring within the original JavaScript Console addon as well as the current state of our fork after the latest Alfresco security-related fix release in 6.2.2.25, and corresponding 7.0/7.1/7.2/7.3 hotfixes. The change in question is contained in the commit https://github.com/Alfresco/alfresco-community-repo/commit/57b60bbe0e861dcac5c4b18ab778814740a3ca6c and ensures that after execution by the script processor, the script top-level scope is unset from an internal ThreadLocal, which various Alfresco-internal classes use i.e. to convert script values from/to regular Java values. Specifically, this PR avoids triggering a NullPointerException by avoiding a call to the `ScriptNode.getName` operation, which - unless the name is already cached - will load a node's properties and run through a script to Java conversion routine, trying to use the scope in the process.

### RELATED INFORMATION

Stack trace from the original JavaScript Console addon provided by a Discord user (specific version undetermined, but likely the official 0.6 release):

```
org.springframework.extensions.webscripts.WebScriptException: 11270020 Wrapped Exception (with status template): null
	at org.springframework.extensions.webscripts.AbstractWebScript.createStatusException(AbstractWebScript.java:1139)
	at de.fme.jsconsole.ExecuteWebscript.executeScriptContent(ExecuteWebscript.java:405)
	at de.fme.jsconsole.ExecuteWebscript.access$100(ExecuteWebscript.java:56)
	at de.fme.jsconsole.ExecuteWebscript$2.execute(ExecuteWebscript.java:280)
	at de.fme.jsconsole.ExecuteWebscript$2.execute(ExecuteWebscript.java:273)
	at org.alfresco.repo.transaction.RetryingTransactionHelper.doInTransaction(RetryingTransactionHelper.java:450)
	at org.alfresco.repo.transaction.RetryingTransactionHelper.doInTransaction(RetryingTransactionHelper.java:338)
	at de.fme.jsconsole.ExecuteWebscript.runWithTransactionIfNeeded(ExecuteWebscript.java:272)
	at de.fme.jsconsole.ExecuteWebscript.access$000(ExecuteWebscript.java:56)
	at de.fme.jsconsole.ExecuteWebscript$1.doWork(ExecuteWebscript.java:250)
	at de.fme.jsconsole.ExecuteWebscript$1.doWork(ExecuteWebscript.java:247)
	at org.alfresco.repo.security.authentication.AuthenticationUtil.runAs(AuthenticationUtil.java:602)
	at de.fme.jsconsole.ExecuteWebscript.runScriptWithTransactionAndAuthentication(ExecuteWebscript.java:247)
	at de.fme.jsconsole.ExecuteWebscript.execute(ExecuteWebscript.java:121)
	at org.alfresco.repo.web.scripts.RepositoryContainer.transactionedExecute(RepositoryContainer.java:474)
	at org.alfresco.repo.web.scripts.RepositoryContainer.transactionedExecuteAs(RepositoryContainer.java:664)
	at org.alfresco.repo.web.scripts.RepositoryContainer.executeScriptInternal(RepositoryContainer.java:435)
	at org.alfresco.repo.web.scripts.RepositoryContainer.executeScript(RepositoryContainer.java:315)
	at org.springframework.extensions.webscripts.AbstractRuntime.executeScript(AbstractRuntime.java:399)
	at org.springframework.extensions.webscripts.AbstractRuntime.executeScript(AbstractRuntime.java:210)
	at org.springframework.extensions.webscripts.servlet.WebScriptServlet.service(WebScriptServlet.java:131)
	at org.alfresco.repo.web.scripts.AlfrescoWebScriptServlet.service(AlfrescoWebScriptServlet.java:43)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:741)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.alfresco.module.aosmodule.service.ContextRootFilter.doFilter(ContextRootFilter.java:93)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.alfresco.web.app.servlet.ServletMetricsFilter.doFilter(ServletMetricsFilter.java:161)
	at org.alfresco.repo.web.filter.beans.BeanProxyFilter.doFilter(BeanProxyFilter.java:89)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.alfresco.web.app.servlet.GlobalLocalizationFilter.doFilter(GlobalLocalizationFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.alfresco.web.app.servlet.ClearSecurityContextFilter.doFilter(ClearSecurityContextFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:199)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:493)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:137)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)
	at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:660)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:798)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:808)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1498)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.NullPointerException
	at org.mozilla.javascript.ScriptableObject.getTopLevelScope(ScriptableObject.java:2236)
	at org.mozilla.javascript.ScriptRuntime.newObject(ScriptRuntime.java:1174)
	at org.alfresco.repo.jscript.ValueConverter.convertValueForScript(ValueConverter.java:105)
	at org.alfresco.repo.jscript.ScriptNode$NodeValueConverter.convertValueForScript(ScriptNode.java:3815)
	at org.alfresco.repo.jscript.ScriptNode$NodeValueConverter.convertValueForScript(ScriptNode.java:3794)
	at org.alfresco.repo.jscript.ScriptNode.getProperties(ScriptNode.java:1008)
	at org.alfresco.repo.jscript.ScriptNode.getName(ScriptNode.java:400)
	at de.fme.jsconsole.ExecuteWebscript.executeScriptContent(ExecuteWebscript.java:362)
	... 56 more
```

The issue could be reproduced using the `org.alfresco:content-services-community:17.184:war` artifact, which is the underlying basis for the latest 7.3 hotfix of Enterprise (though no corresponding 7.3.0.X tag exists in the `acs-packaging` project on GitHub).

The following script is sufficient to reproduce the issue _always_:

```
print('Hello');
```