### PR TITLE
[issue-229] do not persist legacy property-backed-beans from legacy propertybackedbeans on init

### DIFF
--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/config/PropertyBackedBeanPersister.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/config/PropertyBackedBeanPersister.java
@@ -280,12 +280,21 @@ public class PropertyBackedBeanPersister implements InitializingBean
 
         // for some reason most subsystem beans are by default not configured to broadcast property changes
         // JMX only works because it is the only tool / component dealing with this, and only performs direct calls
-        if (propertyBackedBean instanceof AbstractPropertyBackedBean)
+        try
         {
-            ((AbstractPropertyBackedBean) propertyBackedBean).setSaveSetProperty(true);
+            if (propertyBackedBean instanceof AbstractPropertyBackedBean)
+            {
+                ((AbstractPropertyBackedBean) propertyBackedBean).setSaveSetProperty(false);
+            }
+            this.initializeFromPersistedProperties(name, propertyBackedBean);
         }
-
-        this.initializeFromPersistedProperties(name, propertyBackedBean);
+        finally
+        {
+            if (propertyBackedBean instanceof AbstractPropertyBackedBean)
+            {
+                ((AbstractPropertyBackedBean) propertyBackedBean).setSaveSetProperty(true);
+            }
+        }
     }
 
     protected void handleRemovedPropertyBackedBean(final PropertyBackedBean propertyBackedBean, final boolean permanent)


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This fix prevents property-backed-beans configuration being persisted at init. This mitigates issues where breaking configuration is duplicated in the database, ensuring that simple removal of the broken configuration allows for startup.

### RELATED INFORMATION

... If you have any supporting material such as issues that are addressed by this
PR, links outlining any special techniques or libraries used, etc that will help
us to evaluate this PR. Please include that information here...

Fixes #229 

# BE WARNED

- If any of the checklist items are missed, incomplete or invalid we will not accept the PR
- If you are not responsive to feedback on your PR we will not accept the PR
- If we do not accept your PR we will provide feedback on the PR indicating why
- After some time, we will close PRs that have not been accepted

When we decline or close your PR. You are encouraged to address the concerns outlined in the
PR and then re-submit it. We want contributions. We also need for them to be of high quality
and high value and to not take undue resources away from the features and enhancements the
core team is working on. Thanks for understanding!
