### PR TITLE
Fix month in displayed JavaScript Console last execution date

### DIFF
--- a/share/src/main/resources/META-INF/resources/components/ootbee-support-tools/jsconsole.js
+++ b/share/src/main/resources/META-INF/resources/components/ootbee-support-tools/jsconsole.js
@@ -1750,7 +1750,7 @@ if (typeof OOTBee === 'undefined' || !OOTBee)
 
             stats = Dom.get(this.id + '-executionStatsSimple');
             now = new Date();
-            nowAsString = now.getFullYear() + '-' + (now.getMonth() <= 10 ? '0' : '') + (now.getMonth() + 1) + '-' + (now.getDate() < 10 ? '0' : '') + now.getDate() + ' ' + (now.getHours() < 10 ? '0' : '') + now.getHours() + ':' + (now.getMinutes() < 10 ? '0' : '') + now.getMinutes() + ':' + (now.getSeconds() < 10 ? '0' : '') + now.getSeconds();
+            nowAsString = now.getFullYear() + '-' + (now.getMonth() < 9 ? '0' : '') + (now.getMonth() + 1) + '-' + (now.getDate() < 10 ? '0' : '') + now.getDate() + ' ' + (now.getHours() < 10 ? '0' : '') + now.getHours() + ':' + (now.getMinutes() < 10 ? '0' : '') + now.getMinutes() + ':' + (now.getSeconds() < 10 ? '0' : '') + now.getSeconds();
             text = ' - ' + this.msg('label.stats.executed.last') + ' ' + (overallPerf) + 'ms (' + nowAsString + ')';
             stats.innerHTML = '';
             stats.appendChild(document.createTextNode(text));


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR fixes the month value of the last execution date displayed in the JavaScript Console when the month is October or November.

### RELATED INFORMATION

Fixes #227