### PR TITLE
Remove model xml BOM

### DIFF
--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/model/jsconsole-model.xml
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/model/jsconsole-model.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <model name="jsc:jsconsole-model" xmlns="http://www.alfresco.org/model/dictionary/1.0">
 
     <description>Javascript Console Model </description>


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION
In ACS 25 the upgraded version of jibx is using kxml instead of mxl which does not like XML UTF-8 files with a BOM.
I just removed the BOM.
`Caused by: org.xmlpull.v1.XmlPullParserException: PI must not start with xml (position:unknown ﻿@1:5 in org.jibx.runtime.impl.InputStreamWrapper$WrappedStreamUTF8Reader@20e97551) `
