### PR TITLE
Fix Spring version variable name discoverer compatiblity

### DIFF
--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/jsconsole-tern.properties
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/jsconsole-tern.properties
@@ -64,9 +64,9 @@ type.org.alfresco.service.ServiceRegistry.nameOnly=true
 type.org.activiti.engine.delegate.VariableScope.nameOnly=true
 
 type.org.alfresco.repo.jscript.ScriptNode.properties.typeTernName=NodeProperties
-type.org.alfresco.repo.jscript.Person.getImmutableProperties.in.String.out.ScriptableHashMap.typeTernName=NodeProperties
+type.org.alfresco.repo.jscript.Person.getImmutableProperties.out.ScriptableHashMap.in.String.typeTernName=NodeProperties
 type.org.alfresco.repo.workflow.jscript.JscriptWorkflowTask.properties.typeTernName=TaskProperties
-type.org.alfresco.repo.jscript.Search.queryResultSet.in.Object.out.Scriptable.typeTernName=SearchResultSetMeta
+type.org.alfresco.repo.jscript.Search.queryResultSet.out.Scriptable.in.Object.typeTernName=SearchResultSetMeta
 
 # native char is handled as a number
 type.java.lang.String.charAt.out.char.in.int.returnTypeTernName=number
@@ -90,38 +90,38 @@ type.org.alfresco.enterprise.repo.management.script.ScriptMBean.setJmxValueConve
 # some methods / properties use a generic Scriptable type for representing native arrays
 type.org.alfresco.repo.jscript.ScriptNode.children.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
 type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.in.boolean.boolean.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.in.boolean.boolean.Object.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.in.boolean.boolean.Object.int.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.in.boolean.boolean.Object.int.int.int.String.Boolean.String.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.ScriptNode.childrenByXPath.in.String.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.ScriptNode.getChildAssocsByType.in.String.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.ScriptNode.getPropertyNames.in.boolean.out.Scriptable.typeClassName=[Ljava.lang.String;
+type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.out.Scriptable.in.boolean.boolean.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.out.Scriptable.in.boolean.boolean.Object.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.out.Scriptable.in.boolean.boolean.Object.int.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.out.Scriptable.in.boolean.boolean.Object.int.int.int.String.Boolean.String.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.ScriptNode.childrenByXPath.out.Scriptable.in.String.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.ScriptNode.getChildAssocsByType.out.Scriptable.in.String.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.ScriptNode.getPropertyNames.out.Scriptable.in.boolean.typeClassName=[Ljava.lang.String;
 type.org.alfresco.repo.jscript.ScriptNode.typePropertyNames.typeClassName=[Ljava.lang.String;
-type.org.alfresco.repo.jscript.ScriptNode.getTypePropertyNames.in.boolean.out.Scriptable.typeClassName=[Ljava.lang.String;
-type.org.alfresco.repo.jscript.Classification.getAllCategoryNodes.in.String.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.CategoryNode;
-type.org.alfresco.repo.jscript.Classification.getCategoryUsage.in.String.int.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.Classification$Tag;
-type.org.alfresco.repo.jscript.Classification.getRootCategories.in.String.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.CategoryNode;
-type.org.alfresco.repo.jscript.Search.luceneSearch.in.String.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.Search.luceneSearch.in.String.String.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.Search.luceneSearch.in.String.String.boolean.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.Search.luceneSearch.in.String.String.boolean.int.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.Search.luceneSearch.in.String.String.String.boolean.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.Search.luceneSearch.in.String.String.String.boolean.int.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.Search.query.in.Object.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.Search.savedSearch.in.ScriptNode.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.Search.savedSearch.in.String.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.Search.selectNodes.in.String.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.Search.selectNodes.in.String.String.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.Search.xpathSearch.in.String.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.Search.xpathSearch.in.String.String.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.People.getContainerGroups.in.ScriptNode.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.People.getMembers.in.ScriptNode.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
-type.org.alfresco.repo.jscript.People.getMembers.in.ScriptNode.boolean.out.Scriptable.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.ScriptNode.getTypePropertyNames.out.Scriptable.in.boolean.typeClassName=[Ljava.lang.String;
+type.org.alfresco.repo.jscript.Classification.getAllCategoryNodes.out.Scriptable.in.String.typeClassName=[Lorg.alfresco.repo.jscript.CategoryNode;
+type.org.alfresco.repo.jscript.Classification.getCategoryUsage.out.Scriptable.in.String.int.typeClassName=[Lorg.alfresco.repo.jscript.Classification$Tag;
+type.org.alfresco.repo.jscript.Classification.getRootCategories.out.Scriptable.in.String.typeClassName=[Lorg.alfresco.repo.jscript.CategoryNode;
+type.org.alfresco.repo.jscript.Search.luceneSearch.out.Scriptable.in.String.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.Search.luceneSearch.out.Scriptable.in.String.String.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.Search.luceneSearch.out.Scriptable.in.String.String.boolean.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.Search.luceneSearch.out.Scriptable.in.String.String.boolean.int.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.Search.luceneSearch.out.Scriptable.in.String.String.String.boolean.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.Search.luceneSearch.out.Scriptable.in.String.String.String.boolean.int.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.Search.query.out.Scriptable.in.Object.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.Search.savedSearch.out.Scriptable.in.ScriptNode.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.Search.savedSearch.out.Scriptable.in.String.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.Search.selectNodes.out.Scriptable.in.String.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.Search.selectNodes.out.Scriptable.in.String.String.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.Search.xpathSearch.out.Scriptable.in.String.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.Search.xpathSearch.out.Scriptable.in.String.String.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.People.getContainerGroups.out.Scriptable.in.ScriptNode.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.People.getMembers.out.Scriptable.in.ScriptNode.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
+type.org.alfresco.repo.jscript.People.getMembers.out.Scriptable.in.ScriptNode.boolean.typeClassName=[Lorg.alfresco.repo.jscript.ScriptNode;
 # don't know why, but getPeople returns array of NodeRef instead of ScriptNode
-type.org.alfresco.repo.jscript.People.getPeople.in.String.out.Scriptable.typeClassName=[Lorg.alfresco.service.cmr.repository.NodeRef;
-type.org.alfresco.repo.jscript.People.getPeople.in.String.int.out.Scriptable.typeClassName=[Lorg.alfresco.service.cmr.repository.NodeRef;
-type.org.alfresco.repo.jscript.People.getPeople.in.String.int.String.boolean.out.Scriptable.typeClassName=[Lorg.alfresco.service.cmr.repository.NodeRef;
+type.org.alfresco.repo.jscript.People.getPeople.out.Scriptable.in.String.typeClassName=[Lorg.alfresco.service.cmr.repository.NodeRef;
+type.org.alfresco.repo.jscript.People.getPeople.out.Scriptable.in.String.int.typeClassName=[Lorg.alfresco.service.cmr.repository.NodeRef;
+type.org.alfresco.repo.jscript.People.getPeople.out.Scriptable.in.String.int.String.boolean.typeClassName=[Lorg.alfresco.service.cmr.repository.NodeRef;
 type.org.alfresco.repo.jscript.People.getPeoplePaging.in.String.ScriptPagingDetails.String.Boolean.out.Scriptable.typeClassName=[Lorg.alfresco.service.cmr.repository.NodeRef;
 type.org.alfresco.repo.workflow.jscript.WorkflowManager.assignedTasks.typeClassName=[Lorg.alfresco.repo.workflow.jscript.JscriptWorkflowTask;
 type.org.alfresco.repo.workflow.jscript.WorkflowManager.completedTasks.typeClassName=[Lorg.alfresco.repo.workflow.jscript.JscriptWorkflowTask;
@@ -134,14 +134,23 @@ type.org.alfresco.repo.workflow.jscript.JscriptWorkflowPath.tasks.typeClassName=
 
 # some methods expect native-like objects
 # childFileFolders supports JavaString, native String and native array of native String - we opt for the latter for documentation
-type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.in.boolean.boolean.Object.out.Scriptable.arg2.typeTernName=[string]
-type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.in.boolean.boolean.Object.int.out.Scriptable.arg2.typeTernName=[string]
-type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.in.boolean.boolean.Object.int.int.int.String.Boolean.String.out.Scriptable.arg2.typeTernName=[string]
+type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.out.Scriptable.in.boolean.boolean.Object.arg2.typeTernName=[string]
+type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.out.Scriptable.in.boolean.boolean.Object.int.arg2.typeTernName=[string]
+type.org.alfresco.repo.jscript.ScriptNode.childFileFolders.out.Scriptable.in.boolean.boolean.Object.int.int.int.String.Boolean.String.arg2.typeTernName=[string]
+# createNode supports a native Object-like structure for properties
+type.org.alfresco.repo.jscript.ScriptNode.createNode.out.ScriptNode.in.String.String.Object.arg2.typeTernName=object
+type.org.alfresco.repo.jscript.ScriptNode.createNode.out.ScriptNode.in.String.String.Object.String.arg2.typeTernName=object
+type.org.alfresco.repo.jscript.ScriptNode.createNode.out.ScriptNode.in.String.String.Object.String.String.String.arg2.typeTernName=object
+# addAspect supports a native Object-like structure for properties
+type.org.alfresco.repo.jscript.ScriptNode.addAspect.out.boolean.in.String.Object.arg1.typeTernName=object
+# processTemplate supports a native Object-like structure for arguments
+type.org.alfresco.repo.jscript.ScriptNode.processTemplate.out.String.in.ScriptNode.Object.arg1.typeTernName=object
+type.org.alfresco.repo.jscript.ScriptNode.processTemplate.out.String.in.String.Object.arg1.typeTernName=object
 
 type.org.springframework.extensions.webscripts.ConfigModel.script.typeClassName=java.lang.String
 
-type.org.springframework.extensions.webscripts.ScriptMessage.get.in.String.Scriptable.out.String.arg1.typeClassName=[Ljava.lang.String;
-type.org.springframework.extensions.webscripts.ScriptMessage.get.in.String.Scriptable.out.String.arg1.typeTernName=[string]
+type.org.springframework.extensions.webscripts.ScriptMessage.get.out.String.in.String.Scriptable.arg1.typeClassName=[Ljava.lang.String;
+type.org.springframework.extensions.webscripts.ScriptMessage.get.out.String.in.String.Scriptable.arg1.typeTernName=[string]
 
 # default doc without I18n
 type.java.lang.String.ternDoc=Java representation of a string value not wrapped into a native Rhino / JS string


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR changes the use of the Spring parameter name discovery functionality (within the context of the JavaScript Console dynamic tern generation) to prefer the `StandardReflectionParameterNameDiscoverer` and only fall back to the previously used `LocalVariableTableParameterNameDiscoverer` when the former is not available. In Spring 3.x only the latter is available while the latter is not available beginning in Spring 6.1 (used in ACS 25.1 and above).
As a minor side change, this PR fixes the tern properties by aligning in/out variable signatures in the lookup keys with the Java code, and allowing an alternative lookup using the parameter name instead of parameter index.

### RELATED INFORMATION

Fixes #239