### PR TITLE
(#235) Change to snapshot handling

### DIFF
--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/log4j.properties
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/log4j.properties
@@ -1,1 +1,2 @@
 log4j.logger.${basePackage}=INFO
+log4j.logger.${basePackage}.logSnapshotLap=INFO

--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/log4j2.properties
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/log4j2.properties
@@ -1,2 +1,5 @@
 logger.ootbee-support-tools.name=${basePackage}
 logger.ootbee-support-tools.level=INFO
+
+logger.ootbee-support-tools-snapshot.name=${basePackage}.logSnapshotLap
+logger.ootbee-support-tools-snapshot.level=INFO

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j.lib.js
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j.lib.js
@@ -292,10 +292,6 @@ function buildLogFilesModel(useAllLoggerAppenders)
 function logSnapshotLapMessage(message)
 {
     var lapLogger;
-
-    // Fake logger that does not correspond to any class-based logger
-    Packages.org.orderofthebee.addons.support.tools.repo.log.Log4jCompatibilityUtils.LOG4J_HELPER.setLevel('org.orderofthebee.addons.support.tools.repo.logSnapshotLap', 'INFO');
-
     lapLogger = Packages.org.slf4j.LoggerFactory.getLogger('org.orderofthebee.addons.support.tools.repo.logSnapshotLap');
     lapLogger.info(message);
 }


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR fixes an issue with performing log snapshots in ACS versions with Log4j2. Previously, any logger with disabled appender additivity had its configuration changed at runtime to use the snapshot appender. This included false-positives where a logger was undefined and only inherited the disabled additivity from its parent logger - in those cases, the snapshot appender is also inherited when added to the parent logger, but by adding it to the child loggers, they then appeared to be "configured" and were also included in the default listing of "configured loggers".

### RELATED INFORMATION

Fixes #235