### PR TITLE
Dereference virtual nodes in permissions plugin + prepare release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.orderofthebee.support-tools</groupId>
     <artifactId>support-tools-parent</artifactId>
-    <version>1.2.3.0-SNAPSHOT</version>
+    <version>1.2.3.0</version>
     <packaging>pom</packaging>
 
     <name>OOTBee Support Tools - Parent</name>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.orderofthebee.support-tools</groupId>
         <artifactId>support-tools-parent</artifactId>
-        <version>1.2.3.0-SNAPSHOT</version>
+        <version>1.2.3.0</version>
     </parent>
 
     <artifactId>support-tools-repo</artifactId>

--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
@@ -60,6 +60,7 @@ ootbee-support-tools.cache.unknown.clearable=false
 # this maps the final name back to the name used for config lookup
 cache.propertyClassSharedCache.configCacheName=propertyClassCache
 cache.propertyValueSharedCache.configCacheName=propertyValueCache
+cache.authorizationSharedCache.configCacheName=authorizationCache
 
 # (unforked) javascript-console also has a mismatch due to code to manage compatibility with different Alfresco versions
 cache.cache.jsConsoleOutput.configCacheName=jsConsoleOutput
@@ -96,6 +97,7 @@ cache.readersDeniedSharedCache.clearable=true
 cache.nodeOwnerSharedCache.clearable=true
 cache.nodeRulesSharedCache.clearable=true
 cache.personSharedCache.clearable=true
+cache.authorizationCache.clearable=true
 cache.protectedUsersCache.clearable=true
 # clearing either ticket caches will effectively invalidate all active user sessions
 # usernameToTicketIdCache only in ACS 7.0+ as optimisation
@@ -111,7 +113,6 @@ cache.permissionEntitySharedCache.clearable=true
 cache.propertyUniqueContextSharedCache.clearable=true
 cache.siteNodeRefSharedCache.clearable=true
 cache.solrFacetNodeRefSharedCache.clearable=true
-
 cache.folderSizeSharedCache.clearable=true
 cache.contentDiskDriver.fileInfoCache.clearable=true
 

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.orderofthebee.support-tools</groupId>
         <artifactId>support-tools-parent</artifactId>
-        <version>1.2.3.0-SNAPSHOT</version>
+        <version>1.2.3.0</version>
     </parent>
 
     <artifactId>support-tools-share</artifactId>


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR allows checking permissions on virtual node references by de-referencing to the actual node first. In other cases, an appropriate error message is reported. Additionally, this PR adds a minor missing cache config mapping property and prepares the 1.2.3.0 release.

Fixes #205