### PR TITLE
Make Execution of Script in SecureContext configurable

### DIFF
--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/jsconsole/ExecuteWebscript.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/jsconsole/ExecuteWebscript.java
@@ -118,6 +118,8 @@ public class ExecuteWebscript extends AbstractWebScript
     private String preRollScriptClasspath;
 
     private String postRollScriptClasspath;
+    
+    private boolean secureContext;
 
     /**
      *
@@ -159,7 +161,7 @@ public class ExecuteWebscript extends AbstractWebScript
             // Note: Need to use import here so the user-supplied script may also import scripts
             final String script = "<import resource=\"classpath:" + this.preRollScriptClasspath + "\">\n" + jsreq.script;
 
-            final ScriptContent scriptContent = new StringScriptContent(script + this.postRollScript);
+            final ScriptContent scriptContent = new StringScriptContent(script + this.postRollScript, this.secureContext);
 
             final int providedScriptLength = this.countScriptLines(jsreq.script, false);
             final int resolvedScriptLength = this.countScriptLines(script, true);
@@ -610,15 +612,23 @@ public class ExecuteWebscript extends AbstractWebScript
     {
         this.postRollScriptClasspath = postRollScriptClasspath;
     }
+    
+    public void setSecureContext(boolean secureContext) 
+    {
+      this.secureContext = secureContext;
+    }
 
     private static class StringScriptContent implements ScriptContent
     {
 
         private final String content;
+                
+        private final boolean secure;
 
-        public StringScriptContent(final String content)
+        public StringScriptContent(final String content, boolean secure)
         {
             this.content = content;
+            this.secure = secure;
         }
 
         @Override
@@ -654,7 +664,7 @@ public class ExecuteWebscript extends AbstractWebScript
         @Override
         public boolean isSecure()
         {
-            return true;
+            return this.secure;
         }
     }
 

--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/jsconsole/ExecuteWebscript.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/jsconsole/ExecuteWebscript.java
@@ -119,7 +119,7 @@ public class ExecuteWebscript extends AbstractWebScript
 
     private String postRollScriptClasspath;
     
-    private boolean secureContext;
+    private boolean allowUnrestrictedScripts;
 
     /**
      *
@@ -161,7 +161,7 @@ public class ExecuteWebscript extends AbstractWebScript
             // Note: Need to use import here so the user-supplied script may also import scripts
             final String script = "<import resource=\"classpath:" + this.preRollScriptClasspath + "\">\n" + jsreq.script;
 
-            final ScriptContent scriptContent = new StringScriptContent(script + this.postRollScript, this.secureContext);
+            final ScriptContent scriptContent = new StringScriptContent(script + this.postRollScript, this.allowUnrestrictedScripts);
 
             final int providedScriptLength = this.countScriptLines(jsreq.script, false);
             final int resolvedScriptLength = this.countScriptLines(script, true);
@@ -613,9 +613,9 @@ public class ExecuteWebscript extends AbstractWebScript
         this.postRollScriptClasspath = postRollScriptClasspath;
     }
     
-    public void setSecureContext(boolean secureContext) 
+    public final void setAllowUnrestrictedScripts(boolean allowUnrestrictedScripts)
     {
-      this.secureContext = secureContext;
+      this.allowUnrestrictedScripts = allowUnrestrictedScripts;
     }
 
     private static class StringScriptContent implements ScriptContent
@@ -625,7 +625,7 @@ public class ExecuteWebscript extends AbstractWebScript
                 
         private final boolean secure;
 
-        public StringScriptContent(final String content, boolean secure)
+        public StringScriptContent(final String content, final boolean secure)
         {
             this.content = content;
             this.secure = secure;

--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
@@ -9,6 +9,9 @@ ootbee-support-tools.propertyBackedBeanPersister.processLegacyJmxKeysOnRemovePro
 # this flag can be overridden to revert to old behaviour
 ootbee-support-tools.js-console.serverInfo.nodeCountsViaSOLR=true
 
+# true if the scripts in the context are considered secure and may access java.* libs directly otherwise false
+ootbee-support-tools.js-console.scriptContext.secure=true
+
 # it would be unexpected if there ever were so many property backed beans that this limit would not suffice
 cache.propertyBackedBeansPersisterSharedCache.tx.maxItems=1000
 cache.propertyBackedBeansPersisterSharedCache.tx.statsEnabled=${caches.tx.statsEnabled}

--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/alfresco-global.properties
@@ -10,7 +10,7 @@ ootbee-support-tools.propertyBackedBeanPersister.processLegacyJmxKeysOnRemovePro
 ootbee-support-tools.js-console.serverInfo.nodeCountsViaSOLR=true
 
 # true if the scripts in the context are considered secure and may access java.* libs directly otherwise false
-ootbee-support-tools.js-console.scriptContext.secure=true
+ootbee-support-tools.js-console.allowUnrestrictedScripts=true
 
 # it would be unexpected if there ever were so many property backed beans that this limit would not suffice
 cache.propertyBackedBeansPersisterSharedCache.tx.maxItems=1000

--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/module-context.xml
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/module-context.xml
@@ -105,7 +105,7 @@
         </property>
         <property name="preRollScriptClasspath" value="alfresco/module/ootbee-${project.artifactId}/scripts/jsconsole-pre-roll-script.js" />
         <property name="postRollScriptClasspath" value="alfresco/module/ootbee-${project.artifactId}/scripts/jsconsole-post-roll-script.js" />
-        <property name="secureContext" value="${ootbee-support-tools.js-console.scriptContext.secure}"/>
+        <property name="allowUnrestrictedScripts" value="${ootbee-support-tools.js-console.allowUnrestrictedScripts}"/>
     </bean>
 
     <bean id="webscript.org.orderofthebee.support-tools.jsconsole.executionResult.get" class="org.orderofthebee.addons.support.tools.repo.jsconsole.ExecutionResultGet" parent="webscript">

--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/module-context.xml
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/module-context.xml
@@ -105,6 +105,7 @@
         </property>
         <property name="preRollScriptClasspath" value="alfresco/module/ootbee-${project.artifactId}/scripts/jsconsole-pre-roll-script.js" />
         <property name="postRollScriptClasspath" value="alfresco/module/ootbee-${project.artifactId}/scripts/jsconsole-post-roll-script.js" />
+        <property name="secureContext" value="${ootbee-support-tools.js-console.scriptContext.secure}"/>
     </bean>
 
     <bean id="webscript.org.orderofthebee.support-tools.jsconsole.executionResult.get" class="org.orderofthebee.addons.support.tools.repo.jsconsole.ExecutionResultGet" parent="webscript">


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION
This small change makes it configurable whether scripts executed in the JavaScript-Console should run in a secure context or not, with the default configuration not affecting the original behaviour.
This way, for example, the usage of java.* Packages like `java.lang.Runtime` can be prevented by setting the new property `ootbee-support-tools.js-console.scriptContext.secure` from the default value **true** to **false**. 

### RELATED INFORMATION

Fixes #

