### PR TITLE
Handle NoClassDefFoundError when collecting Tern definitions

### DIFF
--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/jsconsole/AlfrescoScriptAPITernGet.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/jsconsole/AlfrescoScriptAPITernGet.java
@@ -749,7 +749,17 @@ public class AlfrescoScriptAPITernGet extends DeclarativeWebScript implements In
             // anything in linear hierarchy would be handled via prototype reference
             if (cls.equals(curCls) || !linearClassHierarchy.contains(curCls))
             {
-                final Method[] declaredMethods = curCls.getDeclaredMethods();
+                final Method[] declaredMethods;
+                try
+                {
+                    declaredMethods = curCls.getDeclaredMethods();
+                }
+                catch (final NoClassDefFoundError ex)
+                {
+                    LOGGER.warn("Skipping Tern method metadata for class {} due to unavailable referenced type", curCls.getName(), ex);
+                    continue;
+                }
+
                 for (final Method declaredMethod : declaredMethods)
                 {
                     final String methodName = declaredMethod.getName();


### PR DESCRIPTION
Upgrading to Alfresco 25.3 and got no class found error. 

```
026-05-21 13:26:49.334 | org.springframework.extensions.webscripts.WebScriptException: 04210001 Wrapped Exception (with status template): javax/transaction/RollbackException
2026-05-21 13:26:49.334 | 	at org.springframework.extensions.webscripts.AbstractWebScript.createStatusException(AbstractWebScript.java:1139)
2026-05-21 13:26:49.334 | 	at org.springframework.extensions.webscripts.DeclarativeWebScript.execute(DeclarativeWebScript.java:171)
2026-05-21 13:26:49.334 | 	at org.alfresco.repo.web.scripts.RepositoryContainer.lambda$transactionedExecute$2(RepositoryContainer.java:562)
2026-05-21 13:26:49.334 | 	at org.alfresco.repo.transaction.RetryingTransactionHelper.doInTransaction(RetryingTransactionHelper.java:444)
2026-05-21 13:26:49.334 | 	at org.alfresco.repo.web.scripts.RepositoryContainer.transactionedExecute(RepositoryContainer.java:553)
2026-05-21 13:26:49.334 | 	at org.alfresco.repo.web.scripts.RepositoryContainer.transactionedExecuteAs(RepositoryContainer.java:697)
2026-05-21 13:26:49.334 | 	at org.alfresco.repo.web.scripts.RepositoryContainer.transactionedExecuteAs(RepositoryContainer.java:737)
2026-05-21 13:26:49.334 | 	at org.alfresco.repo.web.scripts.RepositoryContainer.executeScriptInternal(RepositoryContainer.java:418)
2026-05-21 13:26:49.334 | 	at org.alfresco.repo.web.scripts.RepositoryContainer.executeScript(RepositoryContainer.java:314)
2026-05-21 13:26:49.334 | 	at org.springframework.extensions.webscripts.AbstractRuntime.executeScript(AbstractRuntime.java:423)
2026-05-21 13:26:49.334 | 	at org.springframework.extensions.webscripts.AbstractRuntime.executeScript(AbstractRuntime.java:210)
2026-05-21 13:26:49.334 | 	at org.springframework.extensions.webscripts.servlet.WebScriptServlet.service(WebScriptServlet.java:131)
2026-05-21 13:26:49.334 | 	at org.alfresco.repo.web.scripts.AlfrescoWebScriptServlet.service(AlfrescoWebScriptServlet.java:44)
2026-05-21 13:26:49.334 | 	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
2026-05-21 13:26:49.334 | 	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
2026-05-21 13:26:49.334 | 	at org.alfresco.module.aosmodule.service.ContextRootFilter.doFilter(ContextRootFilter.java:93)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
2026-05-21 13:26:49.334 | 	at org.springframework.extensions.webscripts.servlet.SecurityHeadersFilter.doFilter(SecurityHeadersFilter.java:177)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
2026-05-21 13:26:49.334 | 	at org.alfresco.web.app.servlet.ServletMetricsFilter.doFilter(ServletMetricsFilter.java:159)
2026-05-21 13:26:49.334 | 	at org.alfresco.repo.web.filter.beans.BeanProxyFilter.doFilter(BeanProxyFilter.java:85)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
2026-05-21 13:26:49.334 | 	at org.alfresco.web.app.servlet.GlobalLocalizationFilter.doFilter(GlobalLocalizationFilter.java:70)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
2026-05-21 13:26:49.334 | 	at org.alfresco.web.app.servlet.ClearSecurityContextFilter.doFilter(ClearSecurityContextFilter.java:54)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:165)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:88)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:482)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:113)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:83)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.valves.RemoteIpValve.invoke(RemoteIpValve.java:733)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:654)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:72)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
2026-05-21 13:26:49.334 | 	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:399)
2026-05-21 13:26:49.334 | 	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
2026-05-21 13:26:49.334 | 	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:903)
2026-05-21 13:26:49.334 | 	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1774)
2026-05-21 13:26:49.334 | 	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
2026-05-21 13:26:49.334 | 	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:973)
2026-05-21 13:26:49.334 | 	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:491)
2026-05-21 13:26:49.334 | 	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)
2026-05-21 13:26:49.334 | 	at java.base/java.lang.Thread.run(Thread.java:840)
2026-05-21 13:26:49.334 | Caused by: java.lang.NoClassDefFoundError: javax/transaction/RollbackException
2026-05-21 13:26:49.334 | 	at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
2026-05-21 13:26:49.334 | 	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3402)
2026-05-21 13:26:49.334 | 	at java.base/java.lang.Class.getDeclaredMethods(Class.java:2504)
2026-05-21 13:26:49.334 | 	at org.orderofthebee.addons.support.tools.repo.jsconsole.AlfrescoScriptAPITernGet.collectDocumentableMethods(AlfrescoScriptAPITernGet.java:752)
2026-05-21 13:26:49.334 | 	at org.orderofthebee.addons.support.tools.repo.jsconsole.AlfrescoScriptAPITernGet.fillClassTypeMemberDefinitions(AlfrescoScriptAPITernGet.java:615)
2026-05-21 13:26:49.334 | 	at org.orderofthebee.addons.support.tools.repo.jsconsole.AlfrescoScriptAPITernGet.fillClassTypeDefinition(AlfrescoScriptAPITernGet.java:602)
2026-05-21 13:26:49.334 | 	at org.orderofthebee.addons.support.tools.repo.jsconsole.AlfrescoScriptAPITernGet.prepareJavaTypeDefinitions(AlfrescoScriptAPITernGet.java:411)
2026-05-21 13:26:49.334 | 	at org.orderofthebee.addons.support.tools.repo.jsconsole.AlfrescoScriptAPITernGet.prepareCoreScriptAPIJavaTypeDefinitions(AlfrescoScriptAPITernGet.java:289)
2026-05-21 13:26:49.334 | 	at org.orderofthebee.addons.support.tools.repo.jsconsole.AlfrescoScriptAPITernGet.executeImpl(AlfrescoScriptAPITernGet.java:270)
2026-05-21 13:26:49.334 | 	at org.springframework.extensions.webscripts.DeclarativeWebScript.execute(DeclarativeWebScript.java:64)
2026-05-21 13:26:49.334 | 	... 51 more
2026-05-21 13:26:49.334 | Caused by: java.lang.ClassNotFoundException: javax.transaction.RollbackException
2026-05-21 13:26:49.334 | 	at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1377)
2026-05-21 13:26:49.334 | 	at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1186)
2026-05-21 13:26:49.334 | 	... 61 more
```