### PR TITLE
(#261) Add web script family for helper web scripts

### DIFF
--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions-user.delete.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions-user.delete.desc.xml
@@ -3,10 +3,11 @@
     <shortname>Log Off Active Users</shortname>
     <description>Logs off an active user by invalidating its authentication ticket(s)</description>
     <url>/ootbee/admin/active-sessions/users/{userName}</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <!-- no real change in persistence thus a readonly transaction will do -->
     <transaction allow="readonly">required</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions-users.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/active-sessions-users.get.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Active Sessions Users</shortname>
     <description>Load active user list</description>
     <url>/ootbee/admin/active-sessions/users</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction allow="readonly">required</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/cache-clear.post.desc.xml
@@ -3,6 +3,7 @@
     <shortname>Clear Cache</shortname>
     <description>Clear contents of a cache</description>
     <url>/ootbee/admin/caches/{cache}/clear</url>
+    <family>AdminConsoleHelper</family>
     <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/global-commands.post.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/global-commands.post.desc.xml
@@ -4,6 +4,7 @@
     <description>Executes supported commands of the global command console plugin</description>
     <url>/ootbee/admin/command-console/global/help</url>
     <url>/ootbee/admin/command-console/global/listPlugins</url>
+    <family>AdminConsoleHelper</family>
     <family>OOTBee Support Tools</family>
     <format default="json">any</format>
     <negotiate accept="application/json">json</negotiate>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/permission-commands.post.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/permission-commands.post.desc.xml
@@ -6,6 +6,7 @@
     <url>/ootbee/admin/command-console/permissions/effectivePermission</url>
     <url>/ootbee/admin/command-console/permissions/effectivePermissions</url>
     <url>/ootbee/admin/command-console/permissions/effectiveAuthorisations</url>
+    <family>AdminConsoleHelper</family>
     <family>OOTBee Support Tools</family>
     <format default="json">any</format>
     <negotiate accept="application/json">json</negotiate>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/subsystem-commands.post.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/command-console-plugins/subsystem-commands.post.desc.xml
@@ -12,6 +12,7 @@
     <url>/ootbee/admin/command-console/subsystems/stop</url>
     <url>/ootbee/admin/command-console/subsystems/start</url>
     <url>/ootbee/admin/command-console/subsystems/restart</url>
+    <family>AdminConsoleHelper</family>
     <family>OOTBee Support Tools</family>
     <format default="json">any</format>
     <negotiate accept="application/json">json</negotiate>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/content-service-transform-details.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/content-service-transform-details.get.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Content Service Transform Details</shortname>
     <description>View Content Service Transform Details</description>
     <url>/ootbee/admin/transform-content-service-details</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="html" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction allow="readonly">required</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/hot-threads-getone.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/hot-threads-getone.get.desc.xml
@@ -3,8 +3,9 @@
     <shortname>Hot Threads - GetOne</shortname>
     <description>Generate a single hot threads dump</description>
     <url>/ootbee/admin/hot-threads-getone</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-appenders.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-appenders.get.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Log4J Settings - Appenders</shortname>
     <description>Display Log4J appender details</description>
     <url>/ootbee/admin/log4j-appenders</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="html" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-log-file.delete.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-log-file.delete.desc.xml
@@ -3,6 +3,7 @@
     <shortname>Log4J Settings - Log File</shortname>
     <description>Deletes a specific Log4J log file</description>
     <url>/ootbee/admin/log4j-log-file/{path}</url>
+    <family>AdminConsoleHelper</family>
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-log-file.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-log-file.get.desc.xml
@@ -3,8 +3,9 @@
     <shortname>Log4J Settings - Log File</shortname>
     <description>Accesses a specific Log4J log file</description>
     <url>/ootbee/admin/log4j-log-file/{path}</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-log-files.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-log-files.get.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Log4J Settings - Log Files</shortname>
     <description>Display Log4J log files</description>
     <url>/ootbee/admin/log4j-log-files</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="html" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-log-files.post.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-log-files.post.desc.xml
@@ -3,8 +3,9 @@
     <shortname>Log4J Settings - Log Files ZIP</shortname>
     <description>ZIP Log4J log files</description>
     <url>/ootbee/admin/log4j-log-files</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-logger.delete.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-logger.delete.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Log4J Logger</shortname>
     <description>Reset Log4J logger settings</description>
     <url>/ootbee/admin/log4j-loggers/{logger}</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-logger.post.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-logger.post.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Log4J Logger</shortname>
     <description>Update Log4J logger settings</description>
     <url>/ootbee/admin/log4j-loggers/{logger}</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-logger.put.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-logger.put.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Log4J Logger</shortname>
     <description>Update Log4J logger settings</description>
     <url>/ootbee/admin/log4j-loggers/{logger}</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-loggers.delete.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-loggers.delete.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Log4J Loggers</shortname>
     <description>Reset Log4J Loggers</description>
     <url>/ootbee/admin/log4j-loggers</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-loggers.post.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-loggers.post.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Log4J Logger</shortname>
     <description>Add Log4J Logger</description>
     <url>/ootbee/admin/log4j-loggers</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-complete.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-complete.get.desc.xml
@@ -4,8 +4,9 @@
 	<shortname>Log4J Settings - Log File - Close Snapshot</shortname>
 	<description>Closes (deregisters) a snapshot Log4J appender and retrieves the contents of the associated log file</description>
 	<url>/ootbee/admin/log4j-snapshots/{snapshotUUID}</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
 	<authentication>admin</authentication>
 	<lifecycle>internal</lifecycle>
 	<transaction>none</transaction>
-	<family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-create.post.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-create.post.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Log4J Settings - Log File - Create Snapshot</shortname>
     <description>Creates a snapshot Log4J appender and log file</description>
     <url>/ootbee/admin/log4j-snapshots</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <authentication>admin</authentication>
     <format default="json"/>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-lap.post.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-snapshot-lap.post.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Log4J Snapshot Lap</shortname>
     <description>Log4J Snapshot Log Lap Message</description>
     <url>/ootbee/admin/log4j-snapshot-lap?message={message}</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-tail-events.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-tail-events.get.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Log4J Settings - Tail Events</shortname>
     <description>Loads events from the Log4J log (tail)</description>
     <url>/ootbee/admin/log4j-tail-events</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-tail.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-tail.get.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Log4J Settings - Tail</shortname>
     <description>Display Log4J tail view</description>
     <url>/ootbee/admin/log4j-tail</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="html" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/rendition-service2-localTransform-logs.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/rendition-service2-localTransform-logs.get.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Local Transform Logs</shortname>
     <description>View Local Transform Logs</description>
     <url>/ootbee/admin/transform/renditionService2/{localTransformName}/localTransformLogs</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="html" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction allow="readonly">required</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/rendition-service2-transform-details.post.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/rendition-service2-transform-details.post.desc.xml
@@ -3,9 +3,10 @@
     <shortname>RenditionService2 Transform Details</shortname>
     <description>View / Check RenditionService2 Transform Details</description>
     <url>/ootbee/admin/transform/renditionService2/{operation}</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction allow="readonly">required</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/scheduled-jobs-execute.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/scheduled-jobs-execute.get.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Scheduled Jobs Execution</shortname>
     <description>Execute scheduled jobs</description>
     <url>/ootbee/admin/scheduled-jobs-execute</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="html" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/scheduled-jobs-jobstate.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/scheduled-jobs-jobstate.get.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Job state</shortname>
     <description>delivers the current state of all jobs in alfresco repository</description>
     <url>/ootbee/admin/scheduled-jobs-states</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json"/>
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/scheduled-jobs-pause-trigger.post.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/scheduled-jobs-pause-trigger.post.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Job Trigger Pause</shortname>
     <description>Pauses a particular trigger for a scheduled job</description>
     <url>/ootbee/admin/scheduled-jobs/triggers/{triggerGroup}/{triggerName}/pause</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/scheduled-jobs-resume-trigger.post.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/scheduled-jobs-resume-trigger.post.desc.xml
@@ -3,9 +3,10 @@
     <shortname>Job Trigger Resume</shortname>
     <description>Resumes a particular trigger for a scheduled job</description>
     <url>/ootbee/admin/scheduled-jobs/triggers/{triggerGroup}/{triggerName}/resume</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <format default="json" />
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump-getone.get.desc.xml
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/thread-dump-getone.get.desc.xml
@@ -3,8 +3,9 @@
     <shortname>Thread Dump - GetOne</shortname>
     <description>Generates a single thread dump</description>
     <url>/ootbee/admin/thread-dump-getone</url>
+    <family>AdminConsoleHelper</family>
+    <family>OOTBee Support Tools</family>
     <authentication>admin</authentication>
     <lifecycle>internal</lifecycle>
     <transaction>none</transaction>
-    <family>OOTBee Support Tools</family>
 </webscript>


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR adds the `AdminConsoleHelper` web script family to supporting Support Tools web scripts so that the `RemoteUserAuthenticatorFactory` and `AdminConsoleAuthenticator` approach Alfresco/Hyland has added and expanded to support Identity Services for Admin Console works as expected.

### RELATED INFORMATION

Fixes #261