### PR TITLE
Extend CSRF filter coverage to OOTBee Support Tools admin console web scripts

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -111,6 +111,22 @@
             <artifactId>log4j-core</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!-- include both servlet-api variants since we need their annotations -->
+        <!-- application container will pick up the class(es) with the annotations it supports and ignore the other(s) -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/spring/WebScriptConfigSourceEnhancer.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/spring/WebScriptConfigSourceEnhancer.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2016 - 2026 Order of the Bee
+ *
+ * This file is part of OOTBee Support Tools
+ *
+ * OOTBee Support Tools is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OOTBee Support Tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OOTBee Support Tools. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Linked to Alfresco
+ * Copyright (C) 2005 - 2026 Alfresco Software Limited.
+ */
+package org.orderofthebee.addons.support.tools.repo.spring;
+
+import java.util.List;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.beans.factory.config.ConstructorArgumentValues.ValueHolder;
+import org.springframework.beans.factory.config.TypedStringValue;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.extensions.config.source.UrlConfigSource;
+
+/**
+ * This Spring bean definition registry post processor enhanced the {@code webscripts.configsource} {@link UrlConfigSource} bean definition
+ * to include a custom file provided by our module.
+ *
+ * @author Axel Faust
+ */
+public class WebScriptConfigSourceEnhancer implements BeanDefinitionRegistryPostProcessor
+{
+
+    private static final String REFERENCE_SOURCE_URL = "classpath:alfresco/web-client-security-config.xml";
+
+    private static final String OOTBEE_SOURCE_URL = "classpath:alfresco/module/ootbee-support-tools-repo/web-client-security-config.xml";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void postProcessBeanFactory(final ConfigurableListableBeanFactory beanFactory) throws BeansException
+    {
+        // NO-OP
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void postProcessBeanDefinitionRegistry(final BeanDefinitionRegistry registry) throws BeansException
+    {
+        if (registry.containsBeanDefinition("webscripts.configsource"))
+        {
+            final BeanDefinition beanDefinition = registry.getBeanDefinition("webscripts.configsource");
+            final ConstructorArgumentValues constructorArgumentValues = beanDefinition.getConstructorArgumentValues();
+            final List<ValueHolder> argumentValues = constructorArgumentValues.getGenericArgumentValues();
+            for (final ValueHolder argumentValue : argumentValues)
+            {
+                final Object source = argumentValue.getValue();
+                if (source instanceof List<?>)
+                {
+                    @SuppressWarnings("unchecked")
+                    final List<Object> urls = (List<Object>) source;
+                    for (int i = 0; i < urls.size(); i++)
+                    {
+                        final Object urlCandidate = urls.get(i);
+                        // we want to add our config after the default and before any extension file
+                        if (REFERENCE_SOURCE_URL.equals(urlCandidate) || (urlCandidate instanceof TypedStringValue
+                                && ((TypedStringValue) urlCandidate).getValue().equals(REFERENCE_SOURCE_URL)))
+                        {
+                            urls.add(i + 1, OOTBEE_SOURCE_URL);
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+}

--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/web/JakartaCsrfFilter.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/web/JakartaCsrfFilter.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2016 - 2026 Order of the Bee
+ *
+ * This file is part of OOTBee Support Tools
+ *
+ * OOTBee Support Tools is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OOTBee Support Tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OOTBee Support Tools. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Linked to Alfresco
+ * Copyright (C) 2005 - 2026 Alfresco Software Limited.
+ */
+package org.orderofthebee.addons.support.tools.repo.web;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+
+/**
+ * This filter extends coverage of Alfresco CSRF handling to admin console web scripts of this addon.
+ *
+ * @author Axel Faust
+ */
+@WebFilter(filterName = "OOTBee CRSF Token Filter", urlPatterns = { "/service/ootbee/admin/*", "/s/ootbee/admin/*",
+        "/wcservice/ootbee/admin/*", "/wcs/ootbee/admin/*" })
+public class JakartaCsrfFilter implements Filter
+{
+
+    private Filter actualFilter;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(final FilterConfig filterConfig) throws ServletException
+    {
+        try
+        {
+            final Class<?> cls = Class.forName("org.springframework.extensions.webscripts.servlet.CSRFFilter");
+            this.actualFilter = (Filter) cls.newInstance();
+        }
+        catch (final ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException e)
+        {
+            throw new ServletException("Failed to instantiate actual filter", e);
+        }
+        this.actualFilter.init(filterConfig);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
+            throws IOException, ServletException
+    {
+        this.actualFilter.doFilter(request, response, chain);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void destroy()
+    {
+        this.actualFilter.destroy();
+    }
+}

--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/web/JavaxCsrfFilter.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/web/JavaxCsrfFilter.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2016 - 2026 Order of the Bee
+ *
+ * This file is part of OOTBee Support Tools
+ *
+ * OOTBee Support Tools is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OOTBee Support Tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OOTBee Support Tools. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Linked to Alfresco
+ * Copyright (C) 2005 - 2026 Alfresco Software Limited.
+ */
+package org.orderofthebee.addons.support.tools.repo.web;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+
+/**
+ * This filter extends coverage of Alfresco CSRF handling to admin console web scripts of this addon.
+ *
+ * @author Axel Faust
+ */
+@WebFilter(filterName = "OOTBee CRSF Token Filter", urlPatterns = { "/service/ootbee/admin/*", "/s/ootbee/admin/*",
+        "/wcservice/ootbee/admin/*", "/wcs/ootbee/admin/*" })
+public class JavaxCsrfFilter implements Filter
+{
+
+    private Filter actualFilter;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(final FilterConfig filterConfig) throws ServletException
+    {
+        try
+        {
+            final Class<?> cls = Class.forName("org.springframework.extensions.webscripts.servlet.CSRFFilter");
+            this.actualFilter = (Filter) cls.newInstance();
+        }
+        catch (final ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException e)
+        {
+            throw new ServletException("Failed to instantiate actual filter", e);
+        }
+        this.actualFilter.init(filterConfig);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException
+    {
+        this.actualFilter.doFilter(request, response, chain);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void destroy()
+    {
+        this.actualFilter.destroy();
+    }
+
+}

--- a/repository/src/main/resources/META-INF/resources/ootbee-support-tools/js/admin.js
+++ b/repository/src/main/resources/META-INF/resources/ootbee-support-tools/js/admin.js
@@ -67,6 +67,70 @@ var Admin = Admin || {};
         _ids[key] = id;
     };
 
+    // disabled default CSRF config
+    Admin.CSRF = {
+        enabled: false,
+        cookie: "",
+        header: "",
+        parameter: "",
+        properties: {}
+    };
+
+    /**
+     * Returns the CSRF token.
+     *
+     * Note! Make sure to use this method just before a request is made against the server since it might have been
+     * updated in another browser tab or window.
+     * 
+     * @method CSRFToken
+     * @return {String} The CSRF token or null if not enable or not defined.
+     */
+    Admin.CSRFToken = function CSRFToken()
+    {
+        var token = null, cookieName = Admin.CSRF.getCookie();
+        if (cookieName)
+        {
+            var matches = document.cookie.match(new RegExp("(?:^|; )" + cookieName + "=([^;]*)"));
+            if (matches)
+            {
+                // remove quotes to support Jetty app-server - bug where it quotes a valid cookie value see ALF-18823
+                token = decodeURIComponent(matches[1]).replace(/"/g, '');
+            }
+        }
+        return token;
+    };
+
+    Admin.CSRF.getCookie = function getCookie()
+    {
+        return Admin.substitute(Admin.CSRF.cookie, Admin.CSRF.properties || {});
+    };
+
+    Admin.CSRF.getParameter= function getParameter()
+    {
+        return Admin.substitute(Admin.CSRF.parameter, Admin.CSRF.properties || {});
+    };
+
+    Admin.CSRF.getHeader = function getHeader()
+    {
+        return Admin.substitute(Admin.CSRF.header, Admin.CSRF.properties || {});
+    };
+
+    /**
+     * Simple string substitution helper. Replaces simple instances of templated strings {name} within a string from
+     * a property object. Each key in the property object is replaced in the string with it's value if match is found.
+     * 
+     * @param str  String to replace into
+     * @param properties Object of key/value pairs to replace templates values with
+     */
+    Admin.substitute = function substitute(str, properties)
+    {
+        for (var prop in properties)
+        {
+            str = str.replace("{" + prop + "}", properties[prop]);
+        }
+        return str;
+    };
+
     /**
      * String trim helper
      * 
@@ -318,6 +382,10 @@ var Admin = Admin || {};
             req.overrideMimeType((config.responseContentType ? config.responseContentType : "application/json") + "; charset=utf-8");
         }
         req.open(config.method ? config.method : "GET", config.url);
+        if ((config.method === "POST" || config.method === "PUT") && Admin.CSRF.enabled)
+        {
+            req.setRequestHeader(Admin.CSRF.getHeader(), Admin.CSRFToken());
+        }
         req.setRequestHeader("Content-Type", (config.requestContentType ? config.requestContentType : "application/json") + ";charset=UTF-8");
         req.setRequestHeader("Accept", config.responseContentType ? config.responseContentType : "application/json");
         req.onreadystatechange = function()
@@ -442,6 +510,10 @@ var Admin = Admin || {};
         form.enctype = "multipart/form-data";
         form.target = iframe.name;
         form.action = url;
+        if (Admin.CSRF.enabled)
+        {
+            form.action += "?" + Admin.CSRF.getParameter() + "=" + encodeURIComponent(Admin.CSRFToken());
+        }
         form.appendChild(file);
         form.submit();
     };
@@ -476,6 +548,14 @@ var Admin = Admin || {};
     {
         // get the root form element
         var form = el(_ids.formId);
+
+        // add CSRF token if enabled
+        if (Admin.CSRF.enabled)
+        {
+            var url = form.attributes.action.value;
+            url += (url.lastIndexOf('?') === -1 ? "?" : "&") + Admin.CSRF.getParameter() + "=" + encodeURIComponent(Admin.CSRFToken());
+            form.attributes.action.value = url;
+        }
 
         // ensure ENTER press in a Form field doesn't submit the Form
         Admin.addEventListener(form, 'keypress', function(e)

--- a/repository/src/main/resources/META-INF/resources/ootbee-support-tools/js/admin.js
+++ b/repository/src/main/resources/META-INF/resources/ootbee-support-tools/js/admin.js
@@ -124,9 +124,13 @@ var Admin = Admin || {};
      */
     Admin.substitute = function substitute(str, properties)
     {
-        for (var prop in properties)
+        var prop;
+        for (prop in properties)
         {
-            str = str.replace("{" + prop + "}", properties[prop]);
+            if (properties.hasOwnProperty(prop))
+            {
+                str = str.replace("{" + prop + "}", properties[prop]);
+            }
         }
         return str;
     };

--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/module-context.xml
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/module-context.xml
@@ -4,6 +4,8 @@
            http://www.springframework.org/schema/beans
            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
+    <bean class="org.orderofthebee.addons.support.tools.repo.spring.WebScriptConfigSourceEnhancer" />
+
     <bean class="org.alfresco.i18n.ResourceBundleBootstrapComponent">
         <property name="resourceBundles">
             <list>

--- a/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/web-client-security-config.xml
+++ b/repository/src/main/resources/alfresco/module/ootbee-support-tools-repo/web-client-security-config.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<alfresco-config>
+    <config evaluator="string-compare" condition="CSRFPolicy">
+        <filter>
+            <rule>
+                <request>
+                    <method>GET</method>
+                    <path>/(wc)?s(ervice)?/ootbee/admin/.*</path>
+                </request>
+                <action name="generateToken">
+                    <param name="session">{token}</param>
+                    <param name="cookie">{token}</param>
+                </action>
+            </rule>
+        </filter>
+    </config>
+</alfresco-config>

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/admin-template.ftl
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/admin-template.ftl
@@ -65,24 +65,39 @@ Copyright (C) 2005 - 2025 Alfresco Software Limited.
    <!--[if IE 8 ]><style type="text/css">.dialog{width:100%}</style><![endif]-->
    <script type="text/javascript" src="${url.context}/ootbee-support-tools/js/admin.js"></script>
    <script type="text/javascript">//<![CDATA[
-   
+
+   <#assign CSRF=(config.scoped["CSRFPolicy"]["filter"].getChildren("rule")?size != 0)!false>
+   <#if CSRF>
+      Admin.CSRF.enabled = true;
+      Admin.CSRF.cookie = "${config.scoped["CSRFPolicy"]["client"].getChildValue("cookie")!""}";
+      Admin.CSRF.header = "${config.scoped["CSRFPolicy"]["client"].getChildValue("header")!""}";
+      Admin.CSRF.parameter = "${config.scoped["CSRFPolicy"]["client"].getChildValue("parameter")!""}";
+
+      <#if config.scoped["CSRFPolicy"]["properties"]??>
+         <#assign csrfProperties = (config.scoped["CSRFPolicy"]["properties"].children)![]>
+         <#list csrfProperties as p>
+            Admin.CSRF.properties["${p.name?js_string}"] = "${(p.value!"")?js_string}";
+         </#list>
+      </#if>
+   </#if>
+
    Admin.addMessages({
         requestError: "${msg("admin-console.requesterror")?js_string}",
         passwordHide : "${msg("admin-console.password.hide")?js_string}",
         passwordShow : "${msg("admin-console.password.show")?js_string}"
    });
-   
+
    Admin.registerId("formId", "${FORM_ID}");
-   
+
    //]]></script>
-   
+
    <#list customCSSFiles as cssFile>
         <link rel="stylesheet" type="text/css" href="${url.context}/${cssFile}" />
    </#list>
    <#list customJSFiles as jsFile>
         <script type="text/javascript" src="${url.context}/${jsFile}"></script>
    </#list>
-   
+
 </head>
 <#if !dialog>
 <body>

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       context: ../../repository/target/docker/
     environment:
       CATALINA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:8888"
+      JAVA_OPTS: "-Dcsrf.filter.enabled=true '-Dcsrf.filter.referer=http://localhost:${acs.port}(/.*)?' '-Dcsrf.filter.origin=http://localhost:${acs.port}(/.*)?'"
       JAVA_TOOL_OPTIONS: "${docker.acs.opts}"
     ports:
       - ${acs.port}:8080


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR adds the relevant handling of CSRF tokens to the OOTBee Support Tools Admin Console web scripts, a Spring post-processor to add module-specific CSRF policy extension configuration, and javax/jakarta-aware means to apply the `CSRFFilter` logic to additional servlet paths.

### RELATED INFORMATION

Fixes #223