### PR TITLE
(#275) Fix Share log tailing

### DIFF
--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/log/Log4j1HelperImpl.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/log/Log4j1HelperImpl.java
@@ -270,6 +270,20 @@ public class Log4j1HelperImpl implements Log4jHelper
      * {@inheritDoc}
      */
     @Override
+    public void createTailingAppenderIfNotExists(final String uuid)
+    {
+        final Logger rootLogger = Logger.getRootLogger();
+        Appender appender = rootLogger.getAppender(uuid);
+        if (appender == null) {
+            appender = new Log4j1LimitedListAppender(uuid, 10000);
+            ((Log4j1LimitedListAppender)appender).registerAsAppender(rootLogger);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public List<Path> collectLogFilePaths(final boolean useAllLoggerAppenders)
     {
         final Set<Path> paths = new HashSet<>();

--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/log/Log4j2HelperImpl.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/log/Log4j2HelperImpl.java
@@ -450,6 +450,23 @@ public class Log4j2HelperImpl implements Log4jHelper
      * {@inheritDoc}
      */
     @Override
+    public void createTailingAppenderIfNotExists(final String uuid)
+    {
+        final Logger rootLogger = this.getContext().getLogger(this.getRootLoggerName());
+        if (rootLogger instanceof org.apache.logging.log4j.core.Logger)
+        {
+            Appender appender = ((org.apache.logging.log4j.core.Logger) rootLogger).getAppenders().get(uuid);
+            if (appender == null) {
+                appender = new Log4j2LimitedListAppender(uuid, 10000);
+                ((Log4j2LimitedListAppender)appender).registerAsAppender(rootLogger);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public List<?> retrieveTailingAppenderEvents(final String uuid)
     {
         List<?> events = Collections.emptyList();

--- a/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/log/Log4jHelper.java
+++ b/repository/src/main/java/org/orderofthebee/addons/support/tools/repo/log/Log4jHelper.java
@@ -153,6 +153,15 @@ public interface Log4jHelper
     String createTailingAppender();
 
     /**
+     * Creates an in-memory appender (if it does not exist yet) to collect log output of the root logger for regular polling retrieval. The
+     * tailing appender will be automatically deregistered after an amount of time configured in the system configuration.
+     *
+     * @param uuid
+     *     the UUID of the appender
+     */
+    void createTailingAppenderIfNotExists(String uuid);
+
+    /**
      * Retrieves all collected log events collected by the trailing appender since registration or the last retrieval.
      *
      * @param uuid

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-tail-events.get.json.ftl
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-tail-events.get.json.ftl
@@ -24,6 +24,7 @@ Copyright (C) 2005 - 2025 Alfresco Software Limited.
   -->
 
 {
+    "uuid": "${uuid}",
     "events" : [
         <#if events??><#list events as event>{
             "level" : "${event.level?string}",

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-tail.get.html.ftl
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j-tail.get.html.ftl
@@ -47,7 +47,7 @@ Copyright (C) 2005 - 2025 Alfresco Software Limited.
 
 	<div id="textonlybox" class="textonlybox" style="display: none;" >
         <textarea id="textareaLog" cols=150 rows=60 font=small class="log" wrap="logical" readonly=true >
-        </textarea>		  
+        </textarea>
 	</div>
 
 	<div class="datagrid">

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j.lib.js
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j.lib.js
@@ -176,6 +176,7 @@ function retrieveTailingEvents()
     {
         uuid = Packages.org.orderofthebee.addons.support.tools.repo.log.Log4jCompatibilityUtils.LOG4J_HELPER.createTailingAppender();
     }
+    model.uuid = uuid;
     model.events = Packages.org.orderofthebee.addons.support.tools.repo.log.Log4jCompatibilityUtils.LOG4J_HELPER.retrieveTailingAppenderEvents(uuid);
 }
 

--- a/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j.lib.js
+++ b/repository/src/main/resources/alfresco/templates/webscripts/org/orderofthebee/support-tools/admin/ootbee-support-tools/log4j.lib.js
@@ -167,7 +167,15 @@ function retrieveTailingEvents()
 {
     var uuid;
 
-    uuid = args.uuid ? String(args.uuid) : registerTailingAppender();
+    uuid = args.uuid ? String(args.uuid) : null;
+    if (uuid !== null)
+    {
+        Packages.org.orderofthebee.addons.support.tools.repo.log.Log4jCompatibilityUtils.LOG4J_HELPER.createTailingAppenderIfNotExists(uuid);
+    }
+    else
+    {
+        uuid = Packages.org.orderofthebee.addons.support.tools.repo.log.Log4jCompatibilityUtils.LOG4J_HELPER.createTailingAppender();
+    }
     model.events = Packages.org.orderofthebee.addons.support.tools.repo.log.Log4jCompatibilityUtils.LOG4J_HELPER.retrieveTailingAppenderEvents(uuid);
 }
 

--- a/share/src/main/java/org/orderofthebee/addons/support/tools/share/log/Log4j1HelperImpl.java
+++ b/share/src/main/java/org/orderofthebee/addons/support/tools/share/log/Log4j1HelperImpl.java
@@ -227,6 +227,20 @@ public class Log4j1HelperImpl implements Log4jHelper
      * {@inheritDoc}
      */
     @Override
+    public void createTailingAppenderIfNotExists(final String uuid)
+    {
+        final Logger rootLogger = Logger.getRootLogger();
+        Appender appender = rootLogger.getAppender(uuid);
+        if (appender == null) {
+            appender = new Log4j1LimitedListAppender(uuid, 10000);
+            ((Log4j1LimitedListAppender)appender).registerAsAppender(rootLogger);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public List<Path> collectLogFilePaths(final boolean useAllLoggerAppenders)
     {
         final Set<Path> paths = new HashSet<>();

--- a/share/src/main/java/org/orderofthebee/addons/support/tools/share/log/Log4j2HelperImpl.java
+++ b/share/src/main/java/org/orderofthebee/addons/support/tools/share/log/Log4j2HelperImpl.java
@@ -434,6 +434,23 @@ public class Log4j2HelperImpl implements Log4jHelper
      * {@inheritDoc}
      */
     @Override
+    public void createTailingAppenderIfNotExists(final String uuid)
+    {
+        final Logger rootLogger = this.getContext().getLogger(this.getRootLoggerName());
+        if (rootLogger instanceof org.apache.logging.log4j.core.Logger)
+        {
+            Appender appender = ((org.apache.logging.log4j.core.Logger) rootLogger).getAppenders().get(uuid);
+            if (appender == null) {
+                appender = new Log4j2LimitedListAppender(uuid, 10000);
+                ((Log4j2LimitedListAppender)appender).registerAsAppender(rootLogger);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public List<?> retrieveTailingAppenderEvents(final String uuid)
     {
         List<?> events = Collections.emptyList();

--- a/share/src/main/java/org/orderofthebee/addons/support/tools/share/log/Log4jHelper.java
+++ b/share/src/main/java/org/orderofthebee/addons/support/tools/share/log/Log4jHelper.java
@@ -141,6 +141,15 @@ public interface Log4jHelper
     String createTailingAppender();
 
     /**
+     * Creates an in-memory appender (if it does not exist yet) to collect log output of the root logger for regular polling retrieval. The
+     * tailing appender will be automatically deregistered after an amount of time configured in the system configuration.
+     *
+     * @param uuid
+     *     the UUID of the appender
+     */
+    void createTailingAppenderIfNotExists(String uuid);
+
+    /**
      * Retrieves all collected log events collected by the trailing appender since registration or the last retrieval.
      *
      * @param uuid

--- a/share/src/main/resources/META-INF/resources/ootbee-support-tools/list/LogList.js
+++ b/share/src/main/resources/META-INF/resources/ootbee-support-tools/list/LogList.js
@@ -31,7 +31,7 @@ define([ 'dojo/_base/declare', 'alfresco/lists/AlfList', 'dojo/_base/lang', 'alf
                 loadDataPublishTopic : 'ALF_CRUD_GET_ALL',
 
                 loadDataPublishPayloadDefault : {
-                    url : 'data/console/ootbee-support-tools/log4j-settings-tail',
+                    url : 'data/console/ootbee-support-tools/log4j-tail-events',
                     urlType : 'SHARE'
                 },
 

--- a/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/console/support-tools/log4j-settings.get.js
+++ b/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/console/support-tools/log4j-settings.get.js
@@ -113,7 +113,7 @@ function buildTailButton(repoTier)
                         // TODO Report enhancement - table should not force "loading" to be larger than current table view
                         style : 'min-height: 40ex;',
                         loadDataPublishPayload : {
-                            url : repoTier ? 'ootbee/admin/log4j-tail-events' : 'data/console/ootbee-support-tools/log4j-tail',
+                            url : repoTier ? 'ootbee/admin/log4j-tail-events' : 'data/console/ootbee-support-tools/log4j-tail-events',
                             urlType : repoTier ? 'PROXY' : 'SHARE'
                         }
                     }

--- a/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j-tail-events.get.desc.xml
+++ b/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j-tail-events.get.desc.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<webscript>
+    <shortname>Log4J Settings - Tail Events</shortname>
+    <url>/data/console/ootbee-support-tools/log4j-tail-events</url>
+    <family>OOTBee Support Tools</family>
+    <format default="json" />
+    <authentication>admin</authentication>
+    <lifecycle>internal</lifecycle>
+    <transaction>none</transaction>
+</webscript>

--- a/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j-tail-events.get.js
+++ b/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j-tail-events.get.js
@@ -1,0 +1,26 @@
+<import resource="classpath:alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j.lib.js">
+
+/**
+ * Copyright (C) 2016 - 2025 Order of the Bee
+ *
+ * This file is part of OOTBee Support Tools
+ *
+ * OOTBee Support Tools is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OOTBee Support Tools is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OOTBee Support Tools. If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Linked to Alfresco
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited.
+ */
+
+retrieveTailingEvents();

--- a/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j-tail-events.get.json.ftl
+++ b/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j-tail-events.get.json.ftl
@@ -24,6 +24,7 @@ Copyright (C) 2005 - 2025 Alfresco Software Limited.
   -->
 
 {
+    "uuid": "${uuid}",
     "events" : [
         <#if events??><#list events as event>{
             "level" : "${event.level?string}",

--- a/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j-tail-events.get.json.ftl
+++ b/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j-tail-events.get.json.ftl
@@ -1,0 +1,73 @@
+<#compress>
+<#escape x as jsonUtils.encodeJSONString(x)>
+<#-- 
+Copyright (C) 2016 - 2025 Order of the Bee
+
+This file is part of OOTBee Support Tools
+
+OOTBee Support Tools is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+OOTBee Support Tools is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with OOTBee Support Tools. If not, see <http://www.gnu.org/licenses/>.
+
+Linked to Alfresco
+Copyright (C) 2005 - 2025 Alfresco Software Limited.
+ 
+  -->
+
+{
+    "events" : [
+        <#if events??><#list events as event>{
+            "level" : "${event.level?string}",
+            "loggerName" : "${event.loggerName}",
+            "loggerSimpleName" : "${event.loggerName?substring(event.loggerName?last_index_of(".") + 1)}",
+            "loggerCompressedName" : "${compressName(event.loggerName)}",
+            <#if event.renderedMessage??>
+                "message": "${event.renderedMessage}",
+                "timestamp" : {
+                    "raw" : "${event.timeStamp?c}",
+                    "iso8601" : "${xmldate(event.timeStamp?number_to_datetime)}",
+                    "nice" : "${event.timeStamp?number_to_datetime?string("yyyy-MM-dd HH:mm:ss:SSS")}"
+                }
+            <#else>
+                "message": "${event.message.formattedMessage}",
+                "timestamp" : {
+                    "raw" : "${event.timeMillis?c}",
+                    "iso8601" : "${xmldate(event.timeMillis?number_to_datetime)}",
+                    "nice" : "${event.timeMillis?number_to_datetime?string("yyyy-MM-dd HH:mm:ss:SSS")}"
+                }
+            </#if>
+        }<#if event_has_next>,</#if>
+        </#list></#if>
+    ]
+}
+</#escape>
+</#compress>
+
+<#function compressName loggerName subCall = false>
+    <#local loggerCompressedName = "" />
+    <#if loggerName?contains('$')>
+        <#local loggerCompressedName = compressName(loggerName?substring(0, loggerName?index_of('$')), true) + loggerName?substring(loggerName?index_of('$')) />
+    <#else>
+        <#local fragments = loggerName?split(".") />
+        <#list fragments as loggerNameFragment>
+            <#if loggerNameFragment_index != 0>
+                <#local loggerCompressedName = loggerCompressedName + "." />
+            </#if>
+            <#if loggerNameFragment_index &lt; fragments?size - 2 || (subCall && loggerNameFragment_index &lt; fragments?size - 1)>
+                <#local loggerCompressedName = loggerCompressedName + loggerNameFragment?substring(0, 1) />
+            <#else>
+                <#local loggerCompressedName = loggerCompressedName + loggerNameFragment />
+            </#if>
+        </#list>
+    </#if>
+    <#return loggerCompressedName />
+</#function>

--- a/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j-tail.get.json.ftl
+++ b/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j-tail.get.json.ftl
@@ -22,6 +22,8 @@ Linked to Alfresco
 Copyright (C) 2005 - 2025 Alfresco Software Limited.
  
   -->
-{}
+{
+    "uuid": "${uuid}"
+}
 </#escape>
 </#compress>

--- a/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j-tail.get.json.ftl
+++ b/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j-tail.get.json.ftl
@@ -22,43 +22,6 @@ Linked to Alfresco
 Copyright (C) 2005 - 2025 Alfresco Software Limited.
  
   -->
-
-{
-    "events" : [
-        <#if events??><#list events as event>{
-            "level" : "${event.level?string}",
-            "loggerName" : "${event.loggerName}",
-            "loggerSimpleName" : "${event.loggerName?substring(event.loggerName?last_index_of(".") + 1)}",
-            "loggerCompressedName" : "${compressName(event.loggerName)}",
-            "message": "${event.renderedMessage}",
-            "timestamp" : {
-                "raw" : "${event.timeStamp?c}",
-                "iso8601" : "${xmldate(event.timeStamp?number_to_datetime)}",
-                "nice" : "${event.timeStamp?number_to_datetime?string("yyyy-MM-dd HH:mm:ss:SSS")}"
-            }
-        }<#if event_has_next>,</#if>
-        </#list></#if>
-    ]
-}
+{}
 </#escape>
 </#compress>
-
-<#function compressName loggerName subCall = false>
-    <#local loggerCompressedName = "" />
-    <#if loggerName?contains('$')>
-        <#local loggerCompressedName = compressName(loggerName?substring(0, loggerName?index_of('$')), true) + loggerName?substring(loggerName?index_of('$')) />
-    <#else>
-        <#local fragments = loggerName?split(".") />
-        <#list fragments as loggerNameFragment>
-            <#if loggerNameFragment_index != 0>
-                <#local loggerCompressedName = loggerCompressedName + "." />
-            </#if>
-            <#if loggerNameFragment_index &lt; fragments?size - 2 || (subCall && loggerNameFragment_index &lt; fragments?size - 1)>
-                <#local loggerCompressedName = loggerCompressedName + loggerNameFragment?substring(0, 1) />
-            <#else>
-                <#local loggerCompressedName = loggerCompressedName + loggerNameFragment />
-            </#if>
-        </#list>
-    </#if>
-    <#return loggerCompressedName />
-</#function>

--- a/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j.lib.js
+++ b/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j.lib.js
@@ -167,7 +167,15 @@ function retrieveTailingEvents()
 {
     var uuid;
 
-    uuid = args.uuid ? String(args.uuid) : registerTailingAppender();
+    uuid = args.uuid ? String(args.uuid) : null;
+    if (uuid !== null)
+    {
+        Packages.org.orderofthebee.addons.support.tools.share.log.Log4jCompatibilityUtils.LOG4J_HELPER.createTailingAppenderIfNotExists(uuid);
+    }
+    else
+    {
+        uuid = Packages.org.orderofthebee.addons.support.tools.share.log.Log4jCompatibilityUtils.LOG4J_HELPER.createTailingAppender();
+    }
     model.events = Packages.org.orderofthebee.addons.support.tools.share.log.Log4jCompatibilityUtils.LOG4J_HELPER.retrieveTailingAppenderEvents(uuid);
 }
 

--- a/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j.lib.js
+++ b/share/src/main/resources/alfresco/site-webscripts/org/orderofthebee/support-tools/services/console/log4j.lib.js
@@ -176,6 +176,7 @@ function retrieveTailingEvents()
     {
         uuid = Packages.org.orderofthebee.addons.support.tools.share.log.Log4jCompatibilityUtils.LOG4J_HELPER.createTailingAppender();
     }
+    model.uuid = uuid;
     model.events = Packages.org.orderofthebee.addons.support.tools.share.log.Log4jCompatibilityUtils.LOG4J_HELPER.retrieveTailingAppenderEvents(uuid);
 }
 


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR until the following items are checked off--thank you!

- [x] There aren't existing pull requests attempting to address the issue mentioned here
- [x] Submission developed in a feature branch--not master

### CONVINCING DESCRIPTION

This PR fixes a bug concerning the log tail functionality in Alfresco Share Admin Tools which stemmed from the adaptation to Log4j2 when we updated compatibility to ACS 7.4. Since Share's Aikau page cannot easily do two calls to 1) register and then 2) continuously retrieve log events without more substantial refactoring, but already used a client-side generated UUID for uniqueness of log tail usages, I changed the server-side retrieval handling to do a `createTailingAppenderIfNotExists` with the specified UUID. That way no explicit prior registration is needed.

### RELATED INFORMATION

Fixes #275